### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704498488,
-        "narHash": "sha256-yINKdShHrtjdiJhov+q0s3Y3B830ujRoSbHduUNyKag=",
+        "lastModified": 1704809957,
+        "narHash": "sha256-Z8sBeoeeY2O+BNqh5C+4Z1h1F1wQ2mij7yPZ2GY397M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "51e44a13acea71b36245e8bd8c7db53e0a3e61ee",
+        "rev": "e13aa9e287b3365473e5897e3667ea80a899cdfb",
         "type": "github"
       },
       "original": {

--- a/packages/pipewire/pipewire.nix
+++ b/packages/pipewire/pipewire.nix
@@ -98,7 +98,7 @@ assert ldacbtSupport -> bluezSupport; let
       owner = "pipewire";
       repo = "pipewire";
       rev = "70ffbaed745c23b8415f17745d76623faa4190f1";
-      sha256 = "sha256-aAxzijBgVHTnXaH6K7NcctPdqsPmOV9+j+aIQw2nmpw=";
+      sha256 = "sha256-pDWjZp0xY8oqMbYmA64M2m0MhR985meDSeJC0NgZXwA=";
     };
 
     patches = [


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/51e44a13acea71b36245e8bd8c7db53e0a3e61ee' (2024-01-05)
  → 'github:nix-community/home-manager/e13aa9e287b3365473e5897e3667ea80a899cdfb' (2024-01-09)
```