### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705328944,
-        "narHash": "sha256-joBgIN4n7fVKPjcmQpxq6iWHgflQ9/JwheWHt/410MY=",
+        "lastModified": 1705348229,
+        "narHash": "sha256-CssPema1sBxZkrT95KFuKCNNiqxNe1lnf2QNeXk88Xk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "38af7137e0cf57499f98db55e3b642038f51e849",
+        "rev": "d0b4408eaf782a1ada0a9133bb1cecefdd59c696",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705335923,
-        "narHash": "sha256-jRyp+a89Y7Cb2V/NyIJpgu5gsND419bY16omCZWy+jc=",
+        "lastModified": 1705388820,
+        "narHash": "sha256-k1DwQUSFBHe/85cfje5sddI3lwaXBOwUXEGsEtRtWvQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b989db5900df4bd1a786f8afd8063dae09d89a8c",
+        "rev": "fa152fd745b816dcfc751962f2e20c8669aed8f1",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1705338418,
-        "narHash": "sha256-KtSIxFkwlk3W4I+Hyyk+AjrMxbhXpuF0TrJFwmg1zbc=",
+        "lastModified": 1705341977,
+        "narHash": "sha256-gDV6qK2yBM6o/m09RVDXiBmwXx5oy3H5dO4vsiHxoaA=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "be623b70c21a5f2a766eed177d08728217704e12",
+        "rev": "5667bbc1f40df129dc093ad73a29e0c39c3dcbee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/38af7137e0cf57499f98db55e3b642038f51e849' (2024-01-15)
  → 'github:nix-community/disko/d0b4408eaf782a1ada0a9133bb1cecefdd59c696' (2024-01-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b989db5900df4bd1a786f8afd8063dae09d89a8c' (2024-01-15)
  → 'github:nix-community/home-manager/fa152fd745b816dcfc751962f2e20c8669aed8f1' (2024-01-16)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/be623b70c21a5f2a766eed177d08728217704e12' (2024-01-15)
  → 'github:nix-community/lanzaboote/5667bbc1f40df129dc093ad73a29e0c39c3dcbee' (2024-01-15)
```