### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706798041,
-        "narHash": "sha256-BbvuF4CsVRBGRP8P+R+JUilojk0M60D7hzqE0bEvJBQ=",
+        "lastModified": 1706985585,
+        "narHash": "sha256-ptshv4qXiC6V0GCfpABz88UGGPNwqs5tAxaRUKbk1Qo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4d53427bce7bf3d17e699252fd84dc7468afc46e",
+        "rev": "1ca210648a6ca9b957efde5da957f3de6b1f0c45",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1706732774,
+        "narHash": "sha256-hqJlyJk4MRpcItGYMF+3uHe8HvxNETWvlGtLuVpqLU0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "b8b232ae7b8b144397fdb12d20f592e5e7c1a64d",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1706268017,
-        "narHash": "sha256-0V0zH743F6032dxRh1f6PhEypuLCrUgvCpAOMZJ0htw=",
+        "lastModified": 1706972779,
+        "narHash": "sha256-YWEBA4XuY20rD1ZNFdK+cm/R5oB+DIaM5PnJjSIrzYM=",
         "owner": "upower",
         "repo": "power-profiles-daemon",
-        "rev": "19275d52fa89c18fff51f289d3e552959710e50a",
+        "rev": "9a4229339b486c97b0c25e41211ea2152d9c414a",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/4d53427bce7bf3d17e699252fd84dc7468afc46e' (2024-02-01)
  → 'github:nix-community/home-manager/1ca210648a6ca9b957efde5da957f3de6b1f0c45' (2024-02-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/97b17f32362e475016f942bbdfda4a4a72a8a652' (2024-01-29)
  → 'github:nixos/nixpkgs/b8b232ae7b8b144397fdb12d20f592e5e7c1a64d' (2024-01-31)
• Updated input 'power-profiles-daemon':
    'gitlab:upower/power-profiles-daemon/19275d52fa89c18fff51f289d3e552959710e50a' (2024-01-26)
  → 'gitlab:upower/power-profiles-daemon/9a4229339b486c97b0c25e41211ea2152d9c414a' (2024-02-03)
```