### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706473964,
-        "narHash": "sha256-Fq6xleee/TsX6NbtoRuI96bBuDHMU57PrcK9z1QEKbk=",
+        "lastModified": 1707075082,
+        "narHash": "sha256-PUplk5F5jlIyofxqn/xEDN9pbjrd0tnkd0pDsZ52db0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "c798790eabec3e3da48190ae3698ac227aab770c",
+        "rev": "7d5b46c17d857ee9ddb2e8d88185729a3e5637b6",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704982712,
-        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707114923,
-        "narHash": "sha256-LDYPWa+BgxHSNEye93SyIPgz5u3RAfh78P9KyO+rQzI=",
+        "lastModified": 1707175763,
+        "narHash": "sha256-0MKHC6tQ4KEuM5rui6DjKZ/VNiSANB4E+DJ/+wPS1PU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afcedcf2c8e424d0465e823cf833eb3adebe1db7",
+        "rev": "f99eace7c167b8a6a0871849493b1c613d0f1b80",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1707121189,
-        "narHash": "sha256-mHPNtiJCriz6bHLerN1/ChiyfQ57wLQ6/uBX1FVKaic=",
+        "lastModified": 1707121196,
+        "narHash": "sha256-drevc7MfnMD0Ya811UPDCY5hkCOYXgDYr+oKwWLvF+E=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "436075317deb0fdb95089ea337d5adf721d9a9db",
+        "rev": "f2bc0af580f0bb6e6a2d0bcf0cfb237b357ffbbf",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706913249,
-        "narHash": "sha256-x3M7iV++CsvRXI1fpyFPduGELUckZEhSv0XWnUopAG8=",
+        "lastModified": 1707092692,
+        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e92b6015881907e698782c77641aa49298330223",
+        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1706972779,
-        "narHash": "sha256-YWEBA4XuY20rD1ZNFdK+cm/R5oB+DIaM5PnJjSIrzYM=",
+        "lastModified": 1707154394,
+        "narHash": "sha256-UC93VIlTGtQeMhTRhCrVKq7VgPBvQmfvsd7ZF4KPVDc=",
         "owner": "upower",
         "repo": "power-profiles-daemon",
-        "rev": "9a4229339b486c97b0c25e41211ea2152d9c414a",
+        "rev": "b26d928ddd2309375519c647f19920e4d96df8f6",
         "type": "gitlab"
       },
       "original": {
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706494265,
-        "narHash": "sha256-4ilEUJEwNaY9r/8BpL3VmZiaGber0j09lvvx0e/bosA=",
+        "lastModified": 1707099356,
+        "narHash": "sha256-ph483MDKLi9I/gndYOieVP41es633DOOmPjEI50x5KU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "246ba7102553851af60e0382f558f6bc5f63fa13",
+        "rev": "61dfa5a8129f7edbe9150253c68f673f87b16fb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/afcedcf2c8e424d0465e823cf833eb3adebe1db7' (2024-02-05)
  → 'github:nix-community/home-manager/f99eace7c167b8a6a0871849493b1c613d0f1b80' (2024-02-05)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/436075317deb0fdb95089ea337d5adf721d9a9db' (2024-02-05)
  → 'github:nix-community/lanzaboote/f2bc0af580f0bb6e6a2d0bcf0cfb237b357ffbbf' (2024-02-05)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/c798790eabec3e3da48190ae3698ac227aab770c' (2024-01-28)
  → 'github:ipetkov/crane/7d5b46c17d857ee9ddb2e8d88185729a3e5637b6' (2024-02-04)
• Updated input 'lanzaboote/flake-parts':
    'github:hercules-ci/flake-parts/07f6395285469419cf9d078f59b5b49993198c00' (2024-01-11)
  → 'github:hercules-ci/flake-parts/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f' (2024-02-01)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/246ba7102553851af60e0382f558f6bc5f63fa13' (2024-01-29)
  → 'github:oxalica/rust-overlay/61dfa5a8129f7edbe9150253c68f673f87b16fb1' (2024-02-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e92b6015881907e698782c77641aa49298330223' (2024-02-02)
  → 'github:nixos/nixpkgs/faf912b086576fd1a15fca610166c98d47bc667e' (2024-02-05)
• Updated input 'power-profiles-daemon':
    'gitlab:upower/power-profiles-daemon/9a4229339b486c97b0c25e41211ea2152d9c414a' (2024-02-03)
  → 'gitlab:upower/power-profiles-daemon/b26d928ddd2309375519c647f19920e4d96df8f6' (2024-02-05)
```