### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708988456,
-        "narHash": "sha256-RCz7Xe64tN2zgWk+MVHkzg224znwqknJ1RnB7rVqUWw=",
+        "lastModified": 1709204054,
+        "narHash": "sha256-U1idK0JHs1XOfSI1APYuXi4AEADf+B+ZU4Wifc0pBHk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d085ea4444d26aa52297758b333b449b2aa6fca",
+        "rev": "2f3367769a93b226c467551315e9e270c3f78b15",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1709051793,
-        "narHash": "sha256-4FXFBq5mN1IwN18Fd2OEF1iCZV5PC40gP2L64oyq3xQ=",
+        "lastModified": 1709281415,
+        "narHash": "sha256-2mwO4Orm/5ulDvNxGJJAgcLCvTD2IkcHr9iYiX20img=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e761c7ee47b64debc687d8bff7599d702c893dcc",
+        "rev": "e0a785613a1f8b19a6f3457c67471cdacaeb91c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/1d085ea4444d26aa52297758b333b449b2aa6fca' (2024-02-26)
  → 'github:nix-community/home-manager/2f3367769a93b226c467551315e9e270c3f78b15' (2024-02-29)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/e761c7ee47b64debc687d8bff7599d702c893dcc' (2024-02-27)
  → 'github:nix-community/lanzaboote/e0a785613a1f8b19a6f3457c67471cdacaeb91c3' (2024-03-01)
```