### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708910350,
-        "narHash": "sha256-cTuJVlOm05aQFIgGuYikgkrI61P2vTO2OfXwIRWEzUg=",
+        "lastModified": 1709286488,
+        "narHash": "sha256-RDpTZ72zLu05djvXRzK76Ysqp9zSdh84ax/edEaJucs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a13f36255cf4ce99cc4236a34251c2e7106e101d",
+        "rev": "bde7dd352c07d43bd5b8245e6c39074a391fdd46",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1709281415,
-        "narHash": "sha256-2mwO4Orm/5ulDvNxGJJAgcLCvTD2IkcHr9iYiX20img=",
+        "lastModified": 1709332019,
+        "narHash": "sha256-kJAoPvpVRO3WR1dCZQKJpUMYoyA/6u9iUDX9gGEkjGI=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e0a785613a1f8b19a6f3457c67471cdacaeb91c3",
+        "rev": "eeb45682dd4b2a921a3cab286f13101c9750d6bb",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709150264,
-        "narHash": "sha256-HofykKuisObPUfj0E9CJVfaMhawXkYx3G8UIFR/XQ38=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9099616b93301d5cf84274b184a3a5ec69e94e08",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/a13f36255cf4ce99cc4236a34251c2e7106e101d' (2024-02-26)
  → 'github:nix-community/disko/bde7dd352c07d43bd5b8245e6c39074a391fdd46' (2024-03-01)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/e0a785613a1f8b19a6f3457c67471cdacaeb91c3' (2024-03-01)
  → 'github:nix-community/lanzaboote/eeb45682dd4b2a921a3cab286f13101c9750d6bb' (2024-03-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9099616b93301d5cf84274b184a3a5ec69e94e08' (2024-02-28)
  → 'github:nixos/nixpkgs/1536926ef5621b09bba54035ae2bb6d806d72ac8' (2024-02-29)
```