### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711462743,
-        "narHash": "sha256-3wKGpHy9Kyh98DrziqC/s//60Q0pE17NgbY93L0uWng=",
+        "lastModified": 1711588700,
+        "narHash": "sha256-vBB5HoQVnA6c/UrDOhLXKAahEwSRccw2YXYHxD7qoi4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a6717b1afee7ae955c61eefdf0ce8f864ef78115",
+        "rev": "502241afa3de2a24865ddcbe4c122f4546e32092",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711133180,
-        "narHash": "sha256-WJOahf+6115+GMl3wUfURu8fszuNeJLv9qAWFQl3Vmo=",
+        "lastModified": 1711604890,
+        "narHash": "sha256-vbI/gxRTq/gHW1Q8z6D/7JG/qGNl3JTimUDX+MwnC3A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb",
+        "rev": "3142bdcc470e1e291e1fbe942fd69e06bd00c5df",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711333969,
-        "narHash": "sha256-5PiWGn10DQjMZee5NXzeA6ccsv60iLu+Xtw+mfvkUAs=",
+        "lastModified": 1711523803,
+        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "57e6b3a9e4ebec5aa121188301f04a6b8c354c9b",
+        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
         "type": "github"
       },
       "original": {
@@ -277,11 +277,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1709396627,
-        "narHash": "sha256-FwpVb21zR3lGGKOjwjTUlFmSsCB2gwHjLrmjEA1bMN8=",
+        "lastModified": 1711486576,
+        "narHash": "sha256-Wa/evJi8vmnOCth+jy3kw3Y18wVXg71kck1IKEOp4Kw=",
         "owner": "upower",
         "repo": "power-profiles-daemon",
-        "rev": "bdc60171e57e17819e8b14552ebb9ab4e1ab4bd9",
+        "rev": "87fea138062245deae2e7cdccf4adaacdc4b6ffb",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/a6717b1afee7ae955c61eefdf0ce8f864ef78115' (2024-03-26)
  → 'github:nix-community/disko/502241afa3de2a24865ddcbe4c122f4546e32092' (2024-03-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb' (2024-03-22)
  → 'github:nix-community/home-manager/3142bdcc470e1e291e1fbe942fd69e06bd00c5df' (2024-03-28)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/57e6b3a9e4ebec5aa121188301f04a6b8c354c9b' (2024-03-25)
  → 'github:nixos/nixpkgs/2726f127c15a4cc9810843b96cad73c7eb39e443' (2024-03-27)
• Updated input 'power-profiles-daemon':
    'gitlab:upower/power-profiles-daemon/bdc60171e57e17819e8b14552ebb9ab4e1ab4bd9' (2024-03-02)
  → 'gitlab:upower/power-profiles-daemon/87fea138062245deae2e7cdccf4adaacdc4b6ffb' (2024-03-26)
```