### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712093955,
-        "narHash": "sha256-94I0sXz6fiVBvUAk2tg6t3UpM5rOImj4JTSTNFbg64s=",
+        "lastModified": 1712212014,
+        "narHash": "sha256-s+lbaf3nLRn1++/X2eXwY9mYCA/m9l8AvyG8beeOaXE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "80546b220e95a575c66c213af1b09fe255299438",
+        "rev": "7e91f2a0ba4b62b88591279d54f741a13e36245b",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1711442573,
-        "narHash": "sha256-/A3YzcY5erYOPojp5Ffwgxv4X5MTnRiWwuaXfgXbK2g=",
+        "lastModified": 1712212380,
+        "narHash": "sha256-I9ARWVIrHQ+S+AY4o4lGrfmEXFzoZr+n+yPHep/KfMQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "df7ac26bd24fac8baa94d60a02c3e0f0d4d16368",
+        "rev": "90a97cceec0c29073c28a4c2cd2a3817701ee29b",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1712122226,
+        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
         "type": "github"
       },
       "original": {
@@ -277,11 +277,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1712086079,
-        "narHash": "sha256-qpNzTeEiQGsDPylARwvKiV0DhcU66MWZAwE/JcIA4Dg=",
+        "lastModified": 1712188502,
+        "narHash": "sha256-5JbMbz38SeNEkVKFjJLxeUHiOrx+QCaK/vXgRPbzwzY=",
         "owner": "upower",
         "repo": "power-profiles-daemon",
-        "rev": "b26caea43800b4af188ad76665e186b3d24e641c",
+        "rev": "ae9076ab19e649103ebf07846aaf2b6d1b8240e3",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/80546b220e95a575c66c213af1b09fe255299438' (2024-04-02)
  → 'github:nix-community/home-manager/7e91f2a0ba4b62b88591279d54f741a13e36245b' (2024-04-04)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/df7ac26bd24fac8baa94d60a02c3e0f0d4d16368' (2024-03-26)
  → 'github:nix-community/lanzaboote/90a97cceec0c29073c28a4c2cd2a3817701ee29b' (2024-04-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d8fe5e6c92d0d190646fb9f1056741a229980089' (2024-03-29)
  → 'github:nixos/nixpkgs/08b9151ed40350725eb40b1fe96b0b86304a654b' (2024-04-03)
• Updated input 'power-profiles-daemon':
    'gitlab:upower/power-profiles-daemon/b26caea43800b4af188ad76665e186b3d24e641c' (2024-04-02)
  → 'gitlab:upower/power-profiles-daemon/ae9076ab19e649103ebf07846aaf2b6d1b8240e3' (2024-04-03)
```