### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712356478,
-        "narHash": "sha256-kTcEtrQIRnexu5lAbLsmUcfR2CrmsACF1s3ZFw1NEVA=",
+        "lastModified": 1713152224,
+        "narHash": "sha256-k1aV06cotPwWO3FW+ho+dEoGjxNM303+UmhiG2o6XPs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0a17298c0d96190ef3be729d594ba202b9c53beb",
+        "rev": "bb5ba68ebb73b5ca7996b64e1457fe885891e78e",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712390667,
-        "narHash": "sha256-ebq+fJZfobqpsAdGDGpxNWSySbQejRwW9cdiil6krCo=",
+        "lastModified": 1713166971,
+        "narHash": "sha256-t0P/rKlsE5l1O3O2LYtAelLzp7PeoPCSzsIietQ1hSM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b787726a8413e11b074cde42704b4af32d95545c",
+        "rev": "1c43dcfac48a2d622797f7ab741670fdbcf8f609",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712439257,
-        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
+        "lastModified": 1712963716,
+        "narHash": "sha256-WKm9CvgCldeIVvRz87iOMi8CFVB1apJlkUT4GGvA0iM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
+        "rev": "cfd6b5fc90b15709b780a5a1619695a88505a176",
         "type": "github"
       },
       "original": {
@@ -277,11 +277,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1712188502,
-        "narHash": "sha256-5JbMbz38SeNEkVKFjJLxeUHiOrx+QCaK/vXgRPbzwzY=",
+        "lastModified": 1712433911,
+        "narHash": "sha256-wburRtVtg/3dUSpqXLaOsaaBIkm2Z8Xlr7PVx98KwkQ=",
         "owner": "upower",
         "repo": "power-profiles-daemon",
-        "rev": "ae9076ab19e649103ebf07846aaf2b6d1b8240e3",
+        "rev": "2e00350f922261329c5203706dbb5dc4426972a6",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/0a17298c0d96190ef3be729d594ba202b9c53beb' (2024-04-05)
  → 'github:nix-community/disko/bb5ba68ebb73b5ca7996b64e1457fe885891e78e' (2024-04-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b787726a8413e11b074cde42704b4af32d95545c' (2024-04-06)
  → 'github:nix-community/home-manager/1c43dcfac48a2d622797f7ab741670fdbcf8f609' (2024-04-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ff0dbd94265ac470dda06a657d5fe49de93b4599' (2024-04-06)
  → 'github:nixos/nixpkgs/cfd6b5fc90b15709b780a5a1619695a88505a176' (2024-04-12)
• Updated input 'power-profiles-daemon':
    'gitlab:upower/power-profiles-daemon/ae9076ab19e649103ebf07846aaf2b6d1b8240e3' (2024-04-03)
  → 'gitlab:upower/power-profiles-daemon/2e00350f922261329c5203706dbb5dc4426972a6' (2024-04-06)
```