### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714008123,
-        "narHash": "sha256-zpJNUuOcVL3Yi60VPvpNhs77uIK1D0Ri2eeHcfdz8yg=",
+        "lastModified": 1714103775,
+        "narHash": "sha256-kcBiIrmqzt3bNTr2GMBfAyA+on8BEKO1iKzzDFQZkjI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "db1150487c7cde696cf5c4bbb599b37b885ca592",
+        "rev": "285e26465a0bae510897ca04da26ce6307c652b4",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713992342,
-        "narHash": "sha256-bW7K4WPo6jhYMo4ZUGoJfog6xJV0XZh8adXqZKunRoc=",
+        "lastModified": 1714042918,
+        "narHash": "sha256-4AItZA3EQIiSNAxliuYEJumw/LaVfrMv84gYyrs0r3U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f072c127c041eec36621b8e38a531fe0fe07961",
+        "rev": "0c5704eceefcb7bb238a958f532a86e3b59d76db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/db1150487c7cde696cf5c4bbb599b37b885ca592?narHash=sha256-zpJNUuOcVL3Yi60VPvpNhs77uIK1D0Ri2eeHcfdz8yg%3D' (2024-04-25)
  → 'github:nix-community/disko/285e26465a0bae510897ca04da26ce6307c652b4?narHash=sha256-kcBiIrmqzt3bNTr2GMBfAyA%2Bon8BEKO1iKzzDFQZkjI%3D' (2024-04-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2f072c127c041eec36621b8e38a531fe0fe07961?narHash=sha256-bW7K4WPo6jhYMo4ZUGoJfog6xJV0XZh8adXqZKunRoc%3D' (2024-04-24)
  → 'github:nix-community/home-manager/0c5704eceefcb7bb238a958f532a86e3b59d76db?narHash=sha256-4AItZA3EQIiSNAxliuYEJumw/LaVfrMv84gYyrs0r3U%3D' (2024-04-25)
```