### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714679908,
-        "narHash": "sha256-KzcXzDvDJjX34en8f3Zimm396x6idbt+cu4tWDVS2FI=",
+        "lastModified": 1714894674,
+        "narHash": "sha256-2ZTadZuy42JtuvchRLh5HnQ4943Xkc+I5LVGQGPRFbc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9036fe9ef8e15a819fa76f47a8b1f287903fb848",
+        "rev": "f69bf670d29d3921e00cc626d174654769d743c6",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714635257,
-        "narHash": "sha256-4cPymbty65RvF1DWQfc+Bc8B233A1BWxJnNULJKQ1EY=",
+        "lastModified": 1714763106,
+        "narHash": "sha256-DrDHo74uTycfpAF+/qxZAMlP/Cpe04BVioJb6fdI0YY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63c3a29ca82437c87573e4c6919b09a24ea61b0f",
+        "rev": "e9be42459999a253a9f92559b1f5b72e1b44c13d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/9036fe9ef8e15a819fa76f47a8b1f287903fb848?narHash=sha256-KzcXzDvDJjX34en8f3Zimm396x6idbt%2Bcu4tWDVS2FI%3D' (2024-05-02)
  → 'github:nix-community/home-manager/f69bf670d29d3921e00cc626d174654769d743c6?narHash=sha256-2ZTadZuy42JtuvchRLh5HnQ4943Xkc%2BI5LVGQGPRFbc%3D' (2024-05-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/63c3a29ca82437c87573e4c6919b09a24ea61b0f?narHash=sha256-4cPymbty65RvF1DWQfc%2BBc8B233A1BWxJnNULJKQ1EY%3D' (2024-05-02)
  → 'github:nixos/nixpkgs/e9be42459999a253a9f92559b1f5b72e1b44c13d?narHash=sha256-DrDHo74uTycfpAF%2B/qxZAMlP/Cpe04BVioJb6fdI0YY%3D' (2024-05-03)
```