### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714612856,
-        "narHash": "sha256-W7+rtMzRmdovzndN2NYUv5xzkbMudtQ3jbyFuGk0O1E=",
+        "lastModified": 1714959124,
+        "narHash": "sha256-oYmauPDpSgWjY9hvzwd815igGfP8Ds5Bk6bTo5JrBRk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d57058eb09dd5ec00c746df34fe0a603ea744370",
+        "rev": "e1b3ae2b4ebc3c7b83154b9361e3d154e64e362d",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714894674,
-        "narHash": "sha256-2ZTadZuy42JtuvchRLh5HnQ4943Xkc+I5LVGQGPRFbc=",
+        "lastModified": 1714976273,
+        "narHash": "sha256-IbYND3kbkN/GmV8pK8mglViHbdUgIJ1H48HiRPq2w3E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f69bf670d29d3921e00cc626d174654769d743c6",
+        "rev": "2b87a11125f988a9f67ee63eeaa3682bc841d9b5",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714763106,
-        "narHash": "sha256-DrDHo74uTycfpAF+/qxZAMlP/Cpe04BVioJb6fdI0YY=",
+        "lastModified": 1714906307,
+        "narHash": "sha256-UlRZtrCnhPFSJlDQE7M0eyhgvuuHBTe1eJ9N9AQlJQ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9be42459999a253a9f92559b1f5b72e1b44c13d",
+        "rev": "25865a40d14b3f9cf19f19b924e2ab4069b09588",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/d57058eb09dd5ec00c746df34fe0a603ea744370?narHash=sha256-W7%2BrtMzRmdovzndN2NYUv5xzkbMudtQ3jbyFuGk0O1E%3D' (2024-05-02)
  → 'github:nix-community/disko/e1b3ae2b4ebc3c7b83154b9361e3d154e64e362d?narHash=sha256-oYmauPDpSgWjY9hvzwd815igGfP8Ds5Bk6bTo5JrBRk%3D' (2024-05-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f69bf670d29d3921e00cc626d174654769d743c6?narHash=sha256-2ZTadZuy42JtuvchRLh5HnQ4943Xkc%2BI5LVGQGPRFbc%3D' (2024-05-05)
  → 'github:nix-community/home-manager/2b87a11125f988a9f67ee63eeaa3682bc841d9b5?narHash=sha256-IbYND3kbkN/GmV8pK8mglViHbdUgIJ1H48HiRPq2w3E%3D' (2024-05-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e9be42459999a253a9f92559b1f5b72e1b44c13d?narHash=sha256-DrDHo74uTycfpAF%2B/qxZAMlP/Cpe04BVioJb6fdI0YY%3D' (2024-05-03)
  → 'github:nixos/nixpkgs/25865a40d14b3f9cf19f19b924e2ab4069b09588?narHash=sha256-UlRZtrCnhPFSJlDQE7M0eyhgvuuHBTe1eJ9N9AQlJQ0%3D' (2024-05-05)
```