### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714959124,
-        "narHash": "sha256-oYmauPDpSgWjY9hvzwd815igGfP8Ds5Bk6bTo5JrBRk=",
+        "lastModified": 1715067242,
+        "narHash": "sha256-KCEzKd58z4X0ffHPp9hh2IE255lnprwIl19r1TDzB6o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "e1b3ae2b4ebc3c7b83154b9361e3d154e64e362d",
+        "rev": "874c83c94830d45a64edb408de5a1dd1cae786a4",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714976273,
-        "narHash": "sha256-IbYND3kbkN/GmV8pK8mglViHbdUgIJ1H48HiRPq2w3E=",
+        "lastModified": 1714981474,
+        "narHash": "sha256-b3/U21CJjCjJKmA9WqUbZGZgCvospO3ArOUTgJugkOY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2b87a11125f988a9f67ee63eeaa3682bc841d9b5",
+        "rev": "6ebe7be2e67be7b9b54d61ce5704f6fb466c536f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/e1b3ae2b4ebc3c7b83154b9361e3d154e64e362d?narHash=sha256-oYmauPDpSgWjY9hvzwd815igGfP8Ds5Bk6bTo5JrBRk%3D' (2024-05-06)
  → 'github:nix-community/disko/874c83c94830d45a64edb408de5a1dd1cae786a4?narHash=sha256-KCEzKd58z4X0ffHPp9hh2IE255lnprwIl19r1TDzB6o%3D' (2024-05-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2b87a11125f988a9f67ee63eeaa3682bc841d9b5?narHash=sha256-IbYND3kbkN/GmV8pK8mglViHbdUgIJ1H48HiRPq2w3E%3D' (2024-05-06)
  → 'github:nix-community/home-manager/6ebe7be2e67be7b9b54d61ce5704f6fb466c536f?narHash=sha256-b3/U21CJjCjJKmA9WqUbZGZgCvospO3ArOUTgJugkOY%3D' (2024-05-06)
```