### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715067242,
-        "narHash": "sha256-KCEzKd58z4X0ffHPp9hh2IE255lnprwIl19r1TDzB6o=",
+        "lastModified": 1715070411,
+        "narHash": "sha256-5CNvkH0Nf7yMwgKhjUNg/lUK40C7DXB4zKOuA2jVO90=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "874c83c94830d45a64edb408de5a1dd1cae786a4",
+        "rev": "4677f6c53482a8b01ee93957e3bdd569d51261d6",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714981474,
-        "narHash": "sha256-b3/U21CJjCjJKmA9WqUbZGZgCvospO3ArOUTgJugkOY=",
+        "lastModified": 1715077503,
+        "narHash": "sha256-AfHQshzLQfUqk/efMtdebHaQHqVntCMjhymQzVFLes0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6ebe7be2e67be7b9b54d61ce5704f6fb466c536f",
+        "rev": "6e277d9566de9976f47228dd8c580b97488734d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/874c83c94830d45a64edb408de5a1dd1cae786a4?narHash=sha256-KCEzKd58z4X0ffHPp9hh2IE255lnprwIl19r1TDzB6o%3D' (2024-05-07)
  → 'github:nix-community/disko/4677f6c53482a8b01ee93957e3bdd569d51261d6?narHash=sha256-5CNvkH0Nf7yMwgKhjUNg/lUK40C7DXB4zKOuA2jVO90%3D' (2024-05-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6ebe7be2e67be7b9b54d61ce5704f6fb466c536f?narHash=sha256-b3/U21CJjCjJKmA9WqUbZGZgCvospO3ArOUTgJugkOY%3D' (2024-05-06)
  → 'github:nix-community/home-manager/6e277d9566de9976f47228dd8c580b97488734d4?narHash=sha256-AfHQshzLQfUqk/efMtdebHaQHqVntCMjhymQzVFLes0%3D' (2024-05-07)
```