### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715822638,
-        "narHash": "sha256-Z4ZoyK8jYRmBZwMaEZLEmAilrfdpekwwwohliqC14/E=",
+        "lastModified": 1715872464,
+        "narHash": "sha256-mkZ3hrPG7d+qL7B6pQcrNfPh2mnQEJR3FHK93qCp6Uk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "476eef8d85aa09389ae7baf6e6b60357f6a01432",
+        "rev": "5f6dbcce99d60dd77f96dfc66d06bbea149a40e1",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715486357,
-        "narHash": "sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4=",
+        "lastModified": 1715930644,
+        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
+        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/476eef8d85aa09389ae7baf6e6b60357f6a01432?narHash=sha256-Z4ZoyK8jYRmBZwMaEZLEmAilrfdpekwwwohliqC14/E%3D' (2024-05-16)
  → 'github:nix-community/disko/5f6dbcce99d60dd77f96dfc66d06bbea149a40e1?narHash=sha256-mkZ3hrPG7d%2BqL7B6pQcrNfPh2mnQEJR3FHK93qCp6Uk%3D' (2024-05-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/44677a1c96810a8e8c4ffaeaad10c842402647c1?narHash=sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4%3D' (2024-05-12)
  → 'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d?narHash=sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ%2BNqp%2Bi58O46LI%3D' (2024-05-17)
```