### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716291492,
-        "narHash": "sha256-Qvfoa99WdYIneGrrLFIKQCevLgB5vnxvwJe5aWbGYZY=",
+        "lastModified": 1716773194,
+        "narHash": "sha256-rskkGmWlvYFb+CXedBiL8eWEuED0Es0XR4CkJ11RQKY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "f1654e07728008d354c704d265fc710e3f5f42ee",
+        "rev": "10986091e47fb1180620b78438512b294b7e8f67",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1716736760,
+        "narHash": "sha256-h3RmnNknKYtVA+EvUSra6QAwfZjC2q1G8YA7W0gat8Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "5d151429e1e79107acf6d06dcc5ace4e642ec239",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/f1654e07728008d354c704d265fc710e3f5f42ee?narHash=sha256-Qvfoa99WdYIneGrrLFIKQCevLgB5vnxvwJe5aWbGYZY%3D' (2024-05-21)
  → 'github:nix-community/disko/10986091e47fb1180620b78438512b294b7e8f67?narHash=sha256-rskkGmWlvYFb%2BCXedBiL8eWEuED0Es0XR4CkJ11RQKY%3D' (2024-05-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d?narHash=sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ%2BNqp%2Bi58O46LI%3D' (2024-05-17)
  → 'github:nix-community/home-manager/5d151429e1e79107acf6d06dcc5ace4e642ec239?narHash=sha256-h3RmnNknKYtVA%2BEvUSra6QAwfZjC2q1G8YA7W0gat8Y%3D' (2024-05-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3eaeaeb6b1e08a016380c279f8846e0bd8808916?narHash=sha256-pU9ViBVE3XYb70xZx%2BjK6SEVphvt7xMTbm6yDIF4xPs%3D' (2024-05-21)
  → 'github:nixos/nixpkgs/bfb7a882678e518398ce9a31a881538679f6f092?narHash=sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8%3D' (2024-05-24)
```