### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717535930,
-        "narHash": "sha256-1hZ/txnbd/RmiBPNUs7i8UQw2N89uAK3UzrGAWdnFfU=",
+        "lastModified": 1718078026,
+        "narHash": "sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "55e7754ec31dac78980c8be45f8a28e80e370946",
+        "rev": "a3f0c63eed74a516298932b9b1627dd80b9c3892",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718008439,
-        "narHash": "sha256-nlh/2uD5p2SAdkn6Zuey20yaR5FFWvhL3poapDGNE4Y=",
+        "lastModified": 1718242063,
+        "narHash": "sha256-n3AWItJ4a94GT0cray/eUV7tt3mulQ52L+lWJN9d1E8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "c1cfbfad7cb45f0c177b35b59ba67d1b5fc7ca82",
+        "rev": "832a9f2c81ff3485404bd63952eadc17bf7ccef2",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717931644,
-        "narHash": "sha256-Sz8Wh9cAiD5FhL8UWvZxBfnvxETSCVZlqWSYWaCPyu0=",
+        "lastModified": 1718243258,
+        "narHash": "sha256-abBpj2VU8p6qlRzTU8o22q68MmOaZ4v8zZ4UlYl5YRU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3d65009effd77cb0d6e7520b68b039836a7606cf",
+        "rev": "8d5e27b4807d25308dfe369d5a923d87e7dbfda3",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1717943411,
-        "narHash": "sha256-43QN3+P7UjAz5ZjjUeYGKAyRfv6BLw7jjdc8Ric/6UQ=",
+        "lastModified": 1718218065,
+        "narHash": "sha256-fKC7Ryg3AYykDrS2ilS1VqA8/9B2m3yFZcshK+7tIEc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "56ed078dc92baf72813d55dcfe399715a632bc41",
+        "rev": "7cb05fab896bd542c0ca4260d74d9d664cd7b56e",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717974879,
-        "narHash": "sha256-GTO3C88+5DX171F/gVS3Qga/hOs/eRMxPFpiHq2t+D8=",
+        "lastModified": 1718160348,
+        "narHash": "sha256-9YrUjdztqi4Gz8n3mBuqvCkMo4ojrA6nASwyIKWMpus=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c7b821ba2e1e635ba5a76d299af62821cbcb09f3",
+        "rev": "57d6973abba7ea108bac64ae7629e7431e0199b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/c1cfbfad7cb45f0c177b35b59ba67d1b5fc7ca82?narHash=sha256-nlh/2uD5p2SAdkn6Zuey20yaR5FFWvhL3poapDGNE4Y%3D' (2024-06-10)
  → 'github:nix-community/disko/832a9f2c81ff3485404bd63952eadc17bf7ccef2?narHash=sha256-n3AWItJ4a94GT0cray/eUV7tt3mulQ52L%2BlWJN9d1E8%3D' (2024-06-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/3d65009effd77cb0d6e7520b68b039836a7606cf?narHash=sha256-Sz8Wh9cAiD5FhL8UWvZxBfnvxETSCVZlqWSYWaCPyu0%3D' (2024-06-09)
  → 'github:nix-community/home-manager/8d5e27b4807d25308dfe369d5a923d87e7dbfda3?narHash=sha256-abBpj2VU8p6qlRzTU8o22q68MmOaZ4v8zZ4UlYl5YRU%3D' (2024-06-13)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/56ed078dc92baf72813d55dcfe399715a632bc41?narHash=sha256-43QN3%2BP7UjAz5ZjjUeYGKAyRfv6BLw7jjdc8Ric/6UQ%3D' (2024-06-09)
  → 'github:nix-community/lanzaboote/7cb05fab896bd542c0ca4260d74d9d664cd7b56e?narHash=sha256-fKC7Ryg3AYykDrS2ilS1VqA8/9B2m3yFZcshK%2B7tIEc%3D' (2024-06-12)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/55e7754ec31dac78980c8be45f8a28e80e370946?narHash=sha256-1hZ/txnbd/RmiBPNUs7i8UQw2N89uAK3UzrGAWdnFfU%3D' (2024-06-04)
  → 'github:ipetkov/crane/a3f0c63eed74a516298932b9b1627dd80b9c3892?narHash=sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8%3D' (2024-06-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c7b821ba2e1e635ba5a76d299af62821cbcb09f3?narHash=sha256-GTO3C88%2B5DX171F/gVS3Qga/hOs/eRMxPFpiHq2t%2BD8%3D' (2024-06-09)
  → 'github:nixos/nixpkgs/57d6973abba7ea108bac64ae7629e7431e0199b6?narHash=sha256-9YrUjdztqi4Gz8n3mBuqvCkMo4ojrA6nASwyIKWMpus%3D' (2024-06-12)
```