### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718078026,
-        "narHash": "sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8=",
+        "lastModified": 1718474113,
+        "narHash": "sha256-UKrfy/46YF2TRnxTtKCYzqf2f5ZPRRWwKCCJb7O5X8U=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a3f0c63eed74a516298932b9b1627dd80b9c3892",
+        "rev": "0095fd8ea00ae0a9e6014f39c375e40c2fbd3386",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718242063,
-        "narHash": "sha256-n3AWItJ4a94GT0cray/eUV7tt3mulQ52L+lWJN9d1E8=",
+        "lastModified": 1718846788,
+        "narHash": "sha256-9dtXYtEkmXoUJV+PGLqscqF7qTn4AIhAKpFWRFU2NYs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "832a9f2c81ff3485404bd63952eadc17bf7ccef2",
+        "rev": "e1174d991944a01eaaa04bc59c6281edca4c0e6e",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718243258,
-        "narHash": "sha256-abBpj2VU8p6qlRzTU8o22q68MmOaZ4v8zZ4UlYl5YRU=",
+        "lastModified": 1718788307,
+        "narHash": "sha256-SqiOz0sljM0GjyQEVinPXQxaGcbOXw5OgpCWGPgh/vo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d5e27b4807d25308dfe369d5a923d87e7dbfda3",
+        "rev": "d7830d05421d0ced83a0f007900898bdcaf2a2ca",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1718218065,
-        "narHash": "sha256-fKC7Ryg3AYykDrS2ilS1VqA8/9B2m3yFZcshK+7tIEc=",
+        "lastModified": 1718782018,
+        "narHash": "sha256-8SBmf7Sx5xMLzL4VGEU0fe8cuq0yMumdkXgOPXXD3Bo=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "7cb05fab896bd542c0ca4260d74d9d664cd7b56e",
+        "rev": "6fa7bc0522f71d3906a3788bbd80c344cd9c4523",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718318537,
-        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
+        "lastModified": 1718530797,
+        "narHash": "sha256-pup6cYwtgvzDpvpSCFh1TEUjw2zkNpk8iolbKnyFmmU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
+        "rev": "b60ebf54c15553b393d144357375ea956f89e9a9",
         "type": "github"
       },
       "original": {
@@ -323,11 +323,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717813066,
-        "narHash": "sha256-wqbRwq3i7g5EHIui0bIi84mdqZ/It1AXBSLJ5tafD28=",
+        "lastModified": 1718504420,
+        "narHash": "sha256-F2HT/abCfr0CDpkvXwYCscJyD66XDTLMVfdrIMRp2ck=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6dc3e45fe4aee36efeed24d64fc68b1f989d5465",
+        "rev": "0043c3f92304823cc2c0a4354b0feaa61dfb4cd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/832a9f2c81ff3485404bd63952eadc17bf7ccef2?narHash=sha256-n3AWItJ4a94GT0cray/eUV7tt3mulQ52L%2BlWJN9d1E8%3D' (2024-06-13)
  → 'github:nix-community/disko/e1174d991944a01eaaa04bc59c6281edca4c0e6e?narHash=sha256-9dtXYtEkmXoUJV%2BPGLqscqF7qTn4AIhAKpFWRFU2NYs%3D' (2024-06-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8d5e27b4807d25308dfe369d5a923d87e7dbfda3?narHash=sha256-abBpj2VU8p6qlRzTU8o22q68MmOaZ4v8zZ4UlYl5YRU%3D' (2024-06-13)
  → 'github:nix-community/home-manager/d7830d05421d0ced83a0f007900898bdcaf2a2ca?narHash=sha256-SqiOz0sljM0GjyQEVinPXQxaGcbOXw5OgpCWGPgh/vo%3D' (2024-06-19)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/7cb05fab896bd542c0ca4260d74d9d664cd7b56e?narHash=sha256-fKC7Ryg3AYykDrS2ilS1VqA8/9B2m3yFZcshK%2B7tIEc%3D' (2024-06-12)
  → 'github:nix-community/lanzaboote/6fa7bc0522f71d3906a3788bbd80c344cd9c4523?narHash=sha256-8SBmf7Sx5xMLzL4VGEU0fe8cuq0yMumdkXgOPXXD3Bo%3D' (2024-06-19)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/a3f0c63eed74a516298932b9b1627dd80b9c3892?narHash=sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8%3D' (2024-06-11)
  → 'github:ipetkov/crane/0095fd8ea00ae0a9e6014f39c375e40c2fbd3386?narHash=sha256-UKrfy/46YF2TRnxTtKCYzqf2f5ZPRRWwKCCJb7O5X8U%3D' (2024-06-15)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/6dc3e45fe4aee36efeed24d64fc68b1f989d5465?narHash=sha256-wqbRwq3i7g5EHIui0bIi84mdqZ/It1AXBSLJ5tafD28%3D' (2024-06-08)
  → 'github:oxalica/rust-overlay/0043c3f92304823cc2c0a4354b0feaa61dfb4cd9?narHash=sha256-F2HT/abCfr0CDpkvXwYCscJyD66XDTLMVfdrIMRp2ck%3D' (2024-06-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e9ee548d90ff586a6471b4ae80ae9cfcbceb3420?narHash=sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY%3D' (2024-06-13)
  → 'github:nixos/nixpkgs/b60ebf54c15553b393d144357375ea956f89e9a9?narHash=sha256-pup6cYwtgvzDpvpSCFh1TEUjw2zkNpk8iolbKnyFmmU%3D' (2024-06-16)
```