### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720056646,
-        "narHash": "sha256-BymcV4HWtx2VFuabDCM4/nEJcfivCx0S02wUCz11mAY=",
+        "lastModified": 1720661479,
+        "narHash": "sha256-nsGgA14vVn0GGiqEfomtVgviRJCuSR3UEopfP8ixW1I=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "64679cd7f318c9b6595902b47d4585b1d51d5f9e",
+        "rev": "786965e1b1ed3fd2018d78399984f461e2a44689",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720167120,
-        "narHash": "sha256-K9JYdlPiyaXp33JRg7CT8rMwH56e4ncXSsXW/YKnNXc=",
+        "lastModified": 1720646128,
+        "narHash": "sha256-BivO5yIQukDlJL+1875Sqf3GuOPxZDdA48dYDi3PkL8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba",
+        "rev": "c085b984ff2808bf322f375b10fea5a415a9c43d",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720031269,
-        "narHash": "sha256-rwz8NJZV+387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ=",
+        "lastModified": 1720542800,
+        "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
+        "rev": "feb2849fdeb70028c70d73b848214b00d324a497",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/64679cd7f318c9b6595902b47d4585b1d51d5f9e?narHash=sha256-BymcV4HWtx2VFuabDCM4/nEJcfivCx0S02wUCz11mAY%3D' (2024-07-04)
  → 'github:nix-community/disko/786965e1b1ed3fd2018d78399984f461e2a44689?narHash=sha256-nsGgA14vVn0GGiqEfomtVgviRJCuSR3UEopfP8ixW1I%3D' (2024-07-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba?narHash=sha256-K9JYdlPiyaXp33JRg7CT8rMwH56e4ncXSsXW/YKnNXc%3D' (2024-07-05)
  → 'github:nix-community/home-manager/c085b984ff2808bf322f375b10fea5a415a9c43d?narHash=sha256-BivO5yIQukDlJL%2B1875Sqf3GuOPxZDdA48dYDi3PkL8%3D' (2024-07-10)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9f4128e00b0ae8ec65918efeba59db998750ead6?narHash=sha256-rwz8NJZV%2B387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ%3D' (2024-07-03)
  → 'github:nixos/nixpkgs/feb2849fdeb70028c70d73b848214b00d324a497?narHash=sha256-ZgnNHuKV6h2%2BfQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ%3D' (2024-07-09)
```