### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718474113,
-        "narHash": "sha256-UKrfy/46YF2TRnxTtKCYzqf2f5ZPRRWwKCCJb7O5X8U=",
+        "lastModified": 1718730147,
+        "narHash": "sha256-QmD6B6FYpuoCqu6ZuPJH896ItNquDkn0ulQlOn4ykN8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0095fd8ea00ae0a9e6014f39c375e40c2fbd3386",
+        "rev": "32c21c29b034d0a93fdb2379d6fabc40fc3d0e6c",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720661479,
-        "narHash": "sha256-nsGgA14vVn0GGiqEfomtVgviRJCuSR3UEopfP8ixW1I=",
+        "lastModified": 1721417620,
+        "narHash": "sha256-6q9b1h8fI3hXg2DG6/vrKWCeG8c5Wj2Kvv22RCgedzg=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "786965e1b1ed3fd2018d78399984f461e2a44689",
+        "rev": "bec6e3cde912b8acb915fecdc509eda7c973fb42",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720646128,
-        "narHash": "sha256-BivO5yIQukDlJL+1875Sqf3GuOPxZDdA48dYDi3PkL8=",
+        "lastModified": 1721534365,
+        "narHash": "sha256-XpZOkaSJKdOsz1wU6JfO59Rx2fqtcarQ0y6ndIOKNpI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c085b984ff2808bf322f375b10fea5a415a9c43d",
+        "rev": "635563f245309ef5320f80c7ebcb89b2398d2949",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1719818887,
-        "narHash": "sha256-Bogl1pJlgby7OpR16jp8zwOWV7FHRxCsnNxHcisyIq0=",
+        "lastModified": 1721501207,
+        "narHash": "sha256-umzgs8hXYUyQe6wJm7AnJ3kx8M/h0/WXR2OemAZs3Qs=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0e6457c98547ec8866714d4222545e7e8c1ae429",
+        "rev": "60e4578feca3d894f1474a9b08780c9a5433ad08",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720542800,
-        "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
+        "lastModified": 1721379653,
+        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "feb2849fdeb70028c70d73b848214b00d324a497",
+        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
         "type": "github"
       },
       "original": {
@@ -259,11 +259,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1718447546,
+        "narHash": "sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "842253bf992c3a7157b67600c2857193f126563a",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717664902,
-        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
+        "lastModified": 1718879355,
+        "narHash": "sha256-RTyqP4fBX2MdhNuMP+fnR3lIwbdtXhyj7w7fwtvgspc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
+        "rev": "8cd35b9496d21a6c55164d8547d9d5280162b07a",
         "type": "github"
       },
       "original": {
@@ -313,21 +313,17 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "lanzaboote",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "lanzaboote",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1718504420,
-        "narHash": "sha256-F2HT/abCfr0CDpkvXwYCscJyD66XDTLMVfdrIMRp2ck=",
+        "lastModified": 1719109180,
+        "narHash": "sha256-96dwGCV2yQxDozDATqbsM3YU0ft3Isw3cwVDO/eNCv8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0043c3f92304823cc2c0a4354b0feaa61dfb4cd9",
+        "rev": "5fc5f3a0d7eabf7db86851e6423f9d7fbceaf89d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/786965e1b1ed3fd2018d78399984f461e2a44689?narHash=sha256-nsGgA14vVn0GGiqEfomtVgviRJCuSR3UEopfP8ixW1I%3D' (2024-07-11)
  → 'github:nix-community/disko/bec6e3cde912b8acb915fecdc509eda7c973fb42?narHash=sha256-6q9b1h8fI3hXg2DG6/vrKWCeG8c5Wj2Kvv22RCgedzg%3D' (2024-07-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c085b984ff2808bf322f375b10fea5a415a9c43d?narHash=sha256-BivO5yIQukDlJL%2B1875Sqf3GuOPxZDdA48dYDi3PkL8%3D' (2024-07-10)
  → 'github:nix-community/home-manager/635563f245309ef5320f80c7ebcb89b2398d2949?narHash=sha256-XpZOkaSJKdOsz1wU6JfO59Rx2fqtcarQ0y6ndIOKNpI%3D' (2024-07-21)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/0e6457c98547ec8866714d4222545e7e8c1ae429?narHash=sha256-Bogl1pJlgby7OpR16jp8zwOWV7FHRxCsnNxHcisyIq0%3D' (2024-07-01)
  → 'github:nix-community/lanzaboote/60e4578feca3d894f1474a9b08780c9a5433ad08?narHash=sha256-umzgs8hXYUyQe6wJm7AnJ3kx8M/h0/WXR2OemAZs3Qs%3D' (2024-07-20)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/0095fd8ea00ae0a9e6014f39c375e40c2fbd3386?narHash=sha256-UKrfy/46YF2TRnxTtKCYzqf2f5ZPRRWwKCCJb7O5X8U%3D' (2024-06-15)
  → 'github:ipetkov/crane/32c21c29b034d0a93fdb2379d6fabc40fc3d0e6c?narHash=sha256-QmD6B6FYpuoCqu6ZuPJH896ItNquDkn0ulQlOn4ykN8%3D' (2024-06-18)
• Updated input 'lanzaboote/pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/cc4d466cb1254af050ff7bdf47f6d404a7c646d1?narHash=sha256-7XfBuLULizXjXfBYy/VV%2BSpYMHreNRHk9nKMsm1bgb4%3D' (2024-06-06)
  → 'github:cachix/pre-commit-hooks.nix/8cd35b9496d21a6c55164d8547d9d5280162b07a?narHash=sha256-RTyqP4fBX2MdhNuMP%2BfnR3lIwbdtXhyj7w7fwtvgspc%3D' (2024-06-20)
• Updated input 'lanzaboote/pre-commit-hooks-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/614b4613980a522ba49f0d194531beddbb7220d3?narHash=sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84%3D' (2024-03-17)
  → 'github:NixOS/nixpkgs/842253bf992c3a7157b67600c2857193f126563a?narHash=sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM%3D' (2024-06-15)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/0043c3f92304823cc2c0a4354b0feaa61dfb4cd9?narHash=sha256-F2HT/abCfr0CDpkvXwYCscJyD66XDTLMVfdrIMRp2ck%3D' (2024-06-16)
  → 'github:oxalica/rust-overlay/5fc5f3a0d7eabf7db86851e6423f9d7fbceaf89d?narHash=sha256-96dwGCV2yQxDozDATqbsM3YU0ft3Isw3cwVDO/eNCv8%3D' (2024-06-23)
• Removed input 'lanzaboote/rust-overlay/flake-utils'
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/feb2849fdeb70028c70d73b848214b00d324a497?narHash=sha256-ZgnNHuKV6h2%2BfQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ%3D' (2024-07-09)
  → 'github:nixos/nixpkgs/1d9c2c9b3e71b9ee663d11c5d298727dace8d374?narHash=sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0%3D' (2024-07-19)
```