### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725863684,
-        "narHash": "sha256-HmdTBpuCsw35Ii35JUKO6AE6nae+kJliQb0XGd4hoLE=",
+        "lastModified": 1725948275,
+        "narHash": "sha256-4QOPemDQ9VRLQaAdWuvdDBhh+lEUOAnSMHhdr4nS1mk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "be47a2bdf278c57c2d05e747a13ed31cef54a037",
+        "rev": "e5fa72bad0c6f533e8d558182529ee2acc9454fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/be47a2bdf278c57c2d05e747a13ed31cef54a037?narHash=sha256-HmdTBpuCsw35Ii35JUKO6AE6nae%2BkJliQb0XGd4hoLE%3D' (2024-09-09)
  → 'github:nix-community/home-manager/e5fa72bad0c6f533e8d558182529ee2acc9454fe?narHash=sha256-4QOPemDQ9VRLQaAdWuvdDBhh%2BlEUOAnSMHhdr4nS1mk%3D' (2024-09-10)
```