### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727156717,
-        "narHash": "sha256-Ef7UgoTdOB4PGQKSkHGu6SOxnTiArPHGcRf8qGFC39o=",
+        "lastModified": 1727249977,
+        "narHash": "sha256-lAqOCDI4B6hA+t+KHSm/Go8hQF/Ob5sgXaIRtMAnMKw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "c61e50b63ad50dda5797b1593ad7771be496efbb",
+        "rev": "c1c472f4cd91e4b0703e02810a8c7ed30186b6fa",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727111745,
-        "narHash": "sha256-EYLvFRoTPWtD+3uDg2wwQvlz88OrIr3zld+jFE5gDcY=",
+        "lastModified": 1727246346,
+        "narHash": "sha256-TcUaKtya339Asu+g6KTJ8h7KiKcKXKp2V+At+7tksyY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21c021862fa696c8199934e2153214ab57150cb6",
+        "rev": "1e22ef1518fb175d762006f9cae7f6312b8caedb",
         "type": "github"
       },
       "original": {
@@ -206,11 +206,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726937504,
-        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
+        "lastModified": 1727122398,
+        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
+        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/c61e50b63ad50dda5797b1593ad7771be496efbb?narHash=sha256-Ef7UgoTdOB4PGQKSkHGu6SOxnTiArPHGcRf8qGFC39o%3D' (2024-09-24)
  → 'github:nix-community/disko/c1c472f4cd91e4b0703e02810a8c7ed30186b6fa?narHash=sha256-lAqOCDI4B6hA%2Bt%2BKHSm/Go8hQF/Ob5sgXaIRtMAnMKw%3D' (2024-09-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/21c021862fa696c8199934e2153214ab57150cb6?narHash=sha256-EYLvFRoTPWtD%2B3uDg2wwQvlz88OrIr3zld%2BjFE5gDcY%3D' (2024-09-23)
  → 'github:nix-community/home-manager/1e22ef1518fb175d762006f9cae7f6312b8caedb?narHash=sha256-TcUaKtya339Asu%2Bg6KTJ8h7KiKcKXKp2V%2BAt%2B7tksyY%3D' (2024-09-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9357f4f23713673f310988025d9dc261c20e70c6?narHash=sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c%3D' (2024-09-21)
  → 'github:nixos/nixpkgs/30439d93eb8b19861ccbe3e581abf97bdc91b093?narHash=sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk%3D' (2024-09-23)
```