### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729099656,
-        "narHash": "sha256-VftVIg7UXTy1bq+tzi1aVYOWl7PQ35IpjW88yMYjjpc=",
+        "lastModified": 1729281548,
+        "narHash": "sha256-MuojlSnwAJAwfhgmW8ZtZrwm2Sko4fqubCvReqbUzYw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d7d57edb72e54891fa67a6f058a46b2bb405663b",
+        "rev": "a6a3179ddf396dfc28a078e2f169354d0c137125",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729174520,
-        "narHash": "sha256-QxCAdgQdeIOaCiE0Sr23s9lD0+T1b/wuz5pSiGwNrCQ=",
+        "lastModified": 1729321331,
+        "narHash": "sha256-KVyQq+ez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e78cbb20276f09c1802e62d2f77fc93ec32da268",
+        "rev": "122f70545b29ccb922e655b08acfe05bfb44ec68",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728888510,
-        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
+        "lastModified": 1729070438,
+        "narHash": "sha256-KOTTUfPkugH52avUvXGxvWy8ibKKj4genodIYUED+Kc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+        "rev": "5785b6bb5eaae44e627d541023034e1601455827",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/d7d57edb72e54891fa67a6f058a46b2bb405663b?narHash=sha256-VftVIg7UXTy1bq%2Btzi1aVYOWl7PQ35IpjW88yMYjjpc%3D' (2024-10-16)
  → 'github:nix-community/disko/a6a3179ddf396dfc28a078e2f169354d0c137125?narHash=sha256-MuojlSnwAJAwfhgmW8ZtZrwm2Sko4fqubCvReqbUzYw%3D' (2024-10-18)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e78cbb20276f09c1802e62d2f77fc93ec32da268?narHash=sha256-QxCAdgQdeIOaCiE0Sr23s9lD0%2BT1b/wuz5pSiGwNrCQ%3D' (2024-10-17)
  → 'github:nix-community/home-manager/122f70545b29ccb922e655b08acfe05bfb44ec68?narHash=sha256-KVyQq%2Bez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74%3D' (2024-10-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c?narHash=sha256-nsNdSldaAyu6PE3YUA%2BYQLqUDJh%2BgRbBooMMekZJwvI%3D' (2024-10-14)
  → 'github:nixos/nixpkgs/5785b6bb5eaae44e627d541023034e1601455827?narHash=sha256-KOTTUfPkugH52avUvXGxvWy8ibKKj4genodIYUED%2BKc%3D' (2024-10-16)
```