### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729281548,
-        "narHash": "sha256-MuojlSnwAJAwfhgmW8ZtZrwm2Sko4fqubCvReqbUzYw=",
+        "lastModified": 1729712798,
+        "narHash": "sha256-a+Aakkb+amHw4biOZ0iMo8xYl37uUL48YEXIC5PYJ/8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a6a3179ddf396dfc28a078e2f169354d0c137125",
+        "rev": "09a776702b004fdf9c41a024e1299d575ee18a7d",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729321331,
-        "narHash": "sha256-KVyQq+ez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74=",
+        "lastModified": 1729716953,
+        "narHash": "sha256-FbRKGRRd0amsk/WS/UV9ukJ8jT1dZ2pJBISxkX+uq6A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "122f70545b29ccb922e655b08acfe05bfb44ec68",
+        "rev": "a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729070438,
-        "narHash": "sha256-KOTTUfPkugH52avUvXGxvWy8ibKKj4genodIYUED+Kc=",
+        "lastModified": 1729665710,
+        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5785b6bb5eaae44e627d541023034e1601455827",
+        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/a6a3179ddf396dfc28a078e2f169354d0c137125?narHash=sha256-MuojlSnwAJAwfhgmW8ZtZrwm2Sko4fqubCvReqbUzYw%3D' (2024-10-18)
  → 'github:nix-community/disko/09a776702b004fdf9c41a024e1299d575ee18a7d?narHash=sha256-a%2BAakkb%2BamHw4biOZ0iMo8xYl37uUL48YEXIC5PYJ/8%3D' (2024-10-23)
• Updated input 'home-manager':
    'github:nix-community/home-manager/122f70545b29ccb922e655b08acfe05bfb44ec68?narHash=sha256-KVyQq%2Bez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74%3D' (2024-10-19)
  → 'github:nix-community/home-manager/a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7?narHash=sha256-FbRKGRRd0amsk/WS/UV9ukJ8jT1dZ2pJBISxkX%2Buq6A%3D' (2024-10-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5785b6bb5eaae44e627d541023034e1601455827?narHash=sha256-KOTTUfPkugH52avUvXGxvWy8ibKKj4genodIYUED%2BKc%3D' (2024-10-16)
  → 'github:nixos/nixpkgs/2768c7d042a37de65bb1b5b3268fc987e534c49d?narHash=sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4%3D' (2024-10-23)
```