### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1728776144,
-        "narHash": "sha256-fROVjMcKRoGHofDm8dY3uDUtCMwUICh/KjBFQnuBzfg=",
+        "lastModified": 1730060262,
+        "narHash": "sha256-RMgSVkZ9H03sxC+Vh4jxtLTCzSjPq18UWpiM0gq6shQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "f876e3d905b922502f031aeec1a84490122254b7",
+        "rev": "498d9f122c413ee1154e8131ace5a35a80d8fa76",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729712798,
-        "narHash": "sha256-a+Aakkb+amHw4biOZ0iMo8xYl37uUL48YEXIC5PYJ/8=",
+        "lastModified": 1730190761,
+        "narHash": "sha256-o5m5WzvY6cGIDupuOvjgNSS8AN6yP2iI9MtUC6q/uos=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "09a776702b004fdf9c41a024e1299d575ee18a7d",
+        "rev": "3979285062d6781525cded0f6c4ff92e71376b55",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729716953,
-        "narHash": "sha256-FbRKGRRd0amsk/WS/UV9ukJ8jT1dZ2pJBISxkX+uq6A=",
+        "lastModified": 1730490306,
+        "narHash": "sha256-AvCVDswOUM9D368HxYD25RsSKp+5o0L0/JHADjLoD38=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7",
+        "rev": "1743615b61c7285976f85b303a36cdf88a556503",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1729064530,
-        "narHash": "sha256-oSr/w/5dvf/8ll6NvQlL7+rrK8wzjIcEMP1LvI4Ag08=",
+        "lastModified": 1730107060,
+        "narHash": "sha256-EnVVq1oNcimZmQYl6UlLYs0jhC6aLah0bsFMy2syEak=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "2fa1368f938b50e35ca87334b5aeba38a3402165",
+        "rev": "0ad4ce46649b390da8bebcc229917f9863c98fe2",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1730531603,
+        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728778939,
-        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -288,11 +288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728959392,
-        "narHash": "sha256-fp4he1QQjE+vasDMspZYeXrwTm9otwEqLwEN6FKZ5v0=",
+        "lastModified": 1729996302,
+        "narHash": "sha256-QEU1NQq1+7s1na69Chig9K0iDDTKN0O4Zreo9A9rccA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4c6e317300f05b8871f585b826b6f583e7dc4a9b",
+        "rev": "a1b337569f334ff0a01b57627f17b201d746d24c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/09a776702b004fdf9c41a024e1299d575ee18a7d?narHash=sha256-a%2BAakkb%2BamHw4biOZ0iMo8xYl37uUL48YEXIC5PYJ/8%3D' (2024-10-23)
  → 'github:nix-community/disko/3979285062d6781525cded0f6c4ff92e71376b55?narHash=sha256-o5m5WzvY6cGIDupuOvjgNSS8AN6yP2iI9MtUC6q/uos%3D' (2024-10-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7?narHash=sha256-FbRKGRRd0amsk/WS/UV9ukJ8jT1dZ2pJBISxkX%2Buq6A%3D' (2024-10-23)
  → 'github:nix-community/home-manager/1743615b61c7285976f85b303a36cdf88a556503?narHash=sha256-AvCVDswOUM9D368HxYD25RsSKp%2B5o0L0/JHADjLoD38%3D' (2024-11-01)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/2fa1368f938b50e35ca87334b5aeba38a3402165?narHash=sha256-oSr/w/5dvf/8ll6NvQlL7%2BrrK8wzjIcEMP1LvI4Ag08%3D' (2024-10-16)
  → 'github:nix-community/lanzaboote/0ad4ce46649b390da8bebcc229917f9863c98fe2?narHash=sha256-EnVVq1oNcimZmQYl6UlLYs0jhC6aLah0bsFMy2syEak%3D' (2024-10-28)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/f876e3d905b922502f031aeec1a84490122254b7?narHash=sha256-fROVjMcKRoGHofDm8dY3uDUtCMwUICh/KjBFQnuBzfg%3D' (2024-10-12)
  → 'github:ipetkov/crane/498d9f122c413ee1154e8131ace5a35a80d8fa76?narHash=sha256-RMgSVkZ9H03sxC%2BVh4jxtLTCzSjPq18UWpiM0gq6shQ%3D' (2024-10-27)
• Updated input 'lanzaboote/pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/ff68f91754be6f3427e4986d7949e6273659be1d?narHash=sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe%2B8kX83snTNaFHE%3D' (2024-10-13)
  → 'github:cachix/pre-commit-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6?narHash=sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ%2B/nVtALHIciX/BI%3D' (2024-10-16)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/4c6e317300f05b8871f585b826b6f583e7dc4a9b?narHash=sha256-fp4he1QQjE%2BvasDMspZYeXrwTm9otwEqLwEN6FKZ5v0%3D' (2024-10-15)
  → 'github:oxalica/rust-overlay/a1b337569f334ff0a01b57627f17b201d746d24c?narHash=sha256-QEU1NQq1%2B7s1na69Chig9K0iDDTKN0O4Zreo9A9rccA%3D' (2024-10-27)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/2768c7d042a37de65bb1b5b3268fc987e534c49d?narHash=sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4%3D' (2024-10-23)
  → 'github:nixos/nixpkgs/7ffd9ae656aec493492b44d0ddfb28e79a1ea25d?narHash=sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY%3D' (2024-11-02)
```