### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1730060262,
-        "narHash": "sha256-RMgSVkZ9H03sxC+Vh4jxtLTCzSjPq18UWpiM0gq6shQ=",
+        "lastModified": 1730652660,
+        "narHash": "sha256-+XVYfmVXAiYA0FZT7ijHf555dxCe+AoAT5A6RU+6vSo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "498d9f122c413ee1154e8131ace5a35a80d8fa76",
+        "rev": "a4ca93905455c07cb7e3aca95d4faf7601cba458",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730190761,
-        "narHash": "sha256-o5m5WzvY6cGIDupuOvjgNSS8AN6yP2iI9MtUC6q/uos=",
+        "lastModified": 1731060864,
+        "narHash": "sha256-aYE7oAYZ+gPU1mPNhM0JwLAQNgjf0/JK1BF1ln2KBgk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "3979285062d6781525cded0f6c4ff92e71376b55",
+        "rev": "5e40e02978e3bd63c2a6a9fa6fa8ba0e310e747f",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730490306,
-        "narHash": "sha256-AvCVDswOUM9D368HxYD25RsSKp+5o0L0/JHADjLoD38=",
+        "lastModified": 1730837930,
+        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1743615b61c7285976f85b303a36cdf88a556503",
+        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1730107060,
-        "narHash": "sha256-EnVVq1oNcimZmQYl6UlLYs0jhC6aLah0bsFMy2syEak=",
+        "lastModified": 1730739295,
+        "narHash": "sha256-aYeJ/P/9AuK6Kee63ZdsmDjEwhnksF+gIv/OyGtlBJE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0ad4ce46649b390da8bebcc229917f9863c98fe2",
+        "rev": "cef39a78679c266300874e7a7000b4da066228d4",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730531603,
-        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730302582,
+        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
         "type": "github"
       },
       "original": {
@@ -288,11 +288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729996302,
-        "narHash": "sha256-QEU1NQq1+7s1na69Chig9K0iDDTKN0O4Zreo9A9rccA=",
+        "lastModified": 1730601085,
+        "narHash": "sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a1b337569f334ff0a01b57627f17b201d746d24c",
+        "rev": "8d1b40f8dfd7539aaa3de56e207e22b3cc451825",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/3979285062d6781525cded0f6c4ff92e71376b55?narHash=sha256-o5m5WzvY6cGIDupuOvjgNSS8AN6yP2iI9MtUC6q/uos%3D' (2024-10-29)
  → 'github:nix-community/disko/5e40e02978e3bd63c2a6a9fa6fa8ba0e310e747f?narHash=sha256-aYE7oAYZ%2BgPU1mPNhM0JwLAQNgjf0/JK1BF1ln2KBgk%3D' (2024-11-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1743615b61c7285976f85b303a36cdf88a556503?narHash=sha256-AvCVDswOUM9D368HxYD25RsSKp%2B5o0L0/JHADjLoD38%3D' (2024-11-01)
  → 'github:nix-community/home-manager/2f607e07f3ac7e53541120536708e824acccfaa8?narHash=sha256-0kZL4m%2BbKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc%3D' (2024-11-05)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/0ad4ce46649b390da8bebcc229917f9863c98fe2?narHash=sha256-EnVVq1oNcimZmQYl6UlLYs0jhC6aLah0bsFMy2syEak%3D' (2024-10-28)
  → 'github:nix-community/lanzaboote/cef39a78679c266300874e7a7000b4da066228d4?narHash=sha256-aYeJ/P/9AuK6Kee63ZdsmDjEwhnksF%2BgIv/OyGtlBJE%3D' (2024-11-04)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/498d9f122c413ee1154e8131ace5a35a80d8fa76?narHash=sha256-RMgSVkZ9H03sxC%2BVh4jxtLTCzSjPq18UWpiM0gq6shQ%3D' (2024-10-27)
  → 'github:ipetkov/crane/a4ca93905455c07cb7e3aca95d4faf7601cba458?narHash=sha256-%2BXVYfmVXAiYA0FZT7ijHf555dxCe%2BAoAT5A6RU%2B6vSo%3D' (2024-11-03)
• Updated input 'lanzaboote/flake-parts':
    'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1?narHash=sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0%3D' (2024-10-01)
  → 'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90?narHash=sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS%2Bb4tfNFCwE%3D' (2024-11-01)
• Updated input 'lanzaboote/pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6?narHash=sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ%2B/nVtALHIciX/BI%3D' (2024-10-16)
  → 'github:cachix/pre-commit-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf?narHash=sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU%3D' (2024-10-30)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/a1b337569f334ff0a01b57627f17b201d746d24c?narHash=sha256-QEU1NQq1%2B7s1na69Chig9K0iDDTKN0O4Zreo9A9rccA%3D' (2024-10-27)
  → 'github:oxalica/rust-overlay/8d1b40f8dfd7539aaa3de56e207e22b3cc451825?narHash=sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4%3D' (2024-11-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/7ffd9ae656aec493492b44d0ddfb28e79a1ea25d?narHash=sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY%3D' (2024-11-02)
  → 'github:nixos/nixpkgs/4aa36568d413aca0ea84a1684d2d46f55dbabad7?narHash=sha256-Zwl8YgTVJTEum%2BL%2B0zVAWvXAGbWAuXHax3KzuejaDyo%3D' (2024-11-05)
```