### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731060864,
-        "narHash": "sha256-aYE7oAYZ+gPU1mPNhM0JwLAQNgjf0/JK1BF1ln2KBgk=",
+        "lastModified": 1731549112,
+        "narHash": "sha256-c9I3i1CwZ10SoM5npQQVnfwgvB86jAS3lT4ZqkRoSOI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5e40e02978e3bd63c2a6a9fa6fa8ba0e310e747f",
+        "rev": "5fd852c4155a689098095406500d0ae3d04654a8",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730837930,
-        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
+        "lastModified": 1731535640,
+        "narHash": "sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
+        "rev": "35b055009afd0107b69c286fca34d2ad98940d57",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730785428,
-        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "lastModified": 1731319897,
+        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/5e40e02978e3bd63c2a6a9fa6fa8ba0e310e747f?narHash=sha256-aYE7oAYZ%2BgPU1mPNhM0JwLAQNgjf0/JK1BF1ln2KBgk%3D' (2024-11-08)
  → 'github:nix-community/disko/5fd852c4155a689098095406500d0ae3d04654a8?narHash=sha256-c9I3i1CwZ10SoM5npQQVnfwgvB86jAS3lT4ZqkRoSOI%3D' (2024-11-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2f607e07f3ac7e53541120536708e824acccfaa8?narHash=sha256-0kZL4m%2BbKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc%3D' (2024-11-05)
  → 'github:nix-community/home-manager/35b055009afd0107b69c286fca34d2ad98940d57?narHash=sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM%3D' (2024-11-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4aa36568d413aca0ea84a1684d2d46f55dbabad7?narHash=sha256-Zwl8YgTVJTEum%2BL%2B0zVAWvXAGbWAuXHax3KzuejaDyo%3D' (2024-11-05)
  → 'github:nixos/nixpkgs/dc460ec76cbff0e66e269457d7b728432263166c?narHash=sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY%2B/Z96ZcLpooIbuEI%3D' (2024-11-11)
```