### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732742778,
-        "narHash": "sha256-i+Uw8VOHzQe9YdNwKRbzvaPWLE07tYVqUDzSFTXhRgk=",
+        "lastModified": 1732988076,
+        "narHash": "sha256-2uMaVAZn7fiyTUGhKgleuLYe5+EAAYB/diKxrM7g3as=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "341482e2f4d888e3f60cae1c12c3df896e7230d8",
+        "rev": "2814a5224a47ca19e858e027f7e8bff74a8ea9f1",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732482255,
-        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
+        "lastModified": 1733085484,
+        "narHash": "sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ+GN0r8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
+        "rev": "c1fee8d4a60b89cae12b288ba9dbc608ff298163",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732521221,
-        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
+        "lastModified": 1733015953,
+        "narHash": "sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE+crk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+        "rev": "ac35b104800bff9028425fec3b6e8a41de2bbfff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/341482e2f4d888e3f60cae1c12c3df896e7230d8?narHash=sha256-i%2BUw8VOHzQe9YdNwKRbzvaPWLE07tYVqUDzSFTXhRgk%3D' (2024-11-27)
  → 'github:nix-community/disko/2814a5224a47ca19e858e027f7e8bff74a8ea9f1?narHash=sha256-2uMaVAZn7fiyTUGhKgleuLYe5%2BEAAYB/diKxrM7g3as%3D' (2024-11-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a9953635d7f34e7358d5189751110f87e3ac17da?narHash=sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A%3D' (2024-11-24)
  → 'github:nix-community/home-manager/c1fee8d4a60b89cae12b288ba9dbc608ff298163?narHash=sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ%2BGN0r8%3D' (2024-12-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4633a7c72337ea8fd23a4f2ba3972865e3ec685d?narHash=sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0%3D' (2024-11-25)
  → 'github:nixos/nixpkgs/ac35b104800bff9028425fec3b6e8a41de2bbfff?narHash=sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE%2Bcrk%3D' (2024-12-01)
```