### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732988076,
-        "narHash": "sha256-2uMaVAZn7fiyTUGhKgleuLYe5+EAAYB/diKxrM7g3as=",
+        "lastModified": 1733168902,
+        "narHash": "sha256-8dupm9GfK+BowGdQd7EHK5V61nneLfr9xR6sc5vtDi0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "2814a5224a47ca19e858e027f7e8bff74a8ea9f1",
+        "rev": "785c1e02c7e465375df971949b8dcbde9ec362e5",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733085484,
-        "narHash": "sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ+GN0r8=",
+        "lastModified": 1733354384,
+        "narHash": "sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1fee8d4a60b89cae12b288ba9dbc608ff298163",
+        "rev": "0daaded612b0e6eaed0a63fc9d0778d8f05940fe",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733015953,
-        "narHash": "sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE+crk=",
+        "lastModified": 1733212471,
+        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ac35b104800bff9028425fec3b6e8a41de2bbfff",
+        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/2814a5224a47ca19e858e027f7e8bff74a8ea9f1?narHash=sha256-2uMaVAZn7fiyTUGhKgleuLYe5%2BEAAYB/diKxrM7g3as%3D' (2024-11-30)
  → 'github:nix-community/disko/785c1e02c7e465375df971949b8dcbde9ec362e5?narHash=sha256-8dupm9GfK%2BBowGdQd7EHK5V61nneLfr9xR6sc5vtDi0%3D' (2024-12-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c1fee8d4a60b89cae12b288ba9dbc608ff298163?narHash=sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ%2BGN0r8%3D' (2024-12-01)
  → 'github:nix-community/home-manager/0daaded612b0e6eaed0a63fc9d0778d8f05940fe?narHash=sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM%3D' (2024-12-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ac35b104800bff9028425fec3b6e8a41de2bbfff?narHash=sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE%2Bcrk%3D' (2024-12-01)
  → 'github:nixos/nixpkgs/55d15ad12a74eb7d4646254e13638ad0c4128776?narHash=sha256-M1%2BuCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo%3D' (2024-12-03)
```