### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1730652660,
-        "narHash": "sha256-+XVYfmVXAiYA0FZT7ijHf555dxCe+AoAT5A6RU+6vSo=",
+        "lastModified": 1731098351,
+        "narHash": "sha256-HQkYvKvaLQqNa10KEFGgWHfMAbWBfFp+4cAgkut+NNE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a4ca93905455c07cb7e3aca95d4faf7601cba458",
+        "rev": "ef80ead953c1b28316cc3f8613904edc2eb90c28",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734343412,
-        "narHash": "sha256-b7G8oFp0Nj01BYUJ6ENC9Qf/HsYAIZvN9k/p0Kg/PFU=",
+        "lastModified": 1735468753,
+        "narHash": "sha256-2dt1nOe9zf9pDkf5Kn7FUFyPRo581s0n90jxYXJ94l0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a08bfe06b39e94eec98dd089a2c1b18af01fef19",
+        "rev": "84a5b93637cc16cbfcc61b6e1684d626df61eb21",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734344598,
-        "narHash": "sha256-wNX3hsScqDdqKWOO87wETUEi7a/QlPVgpC/Lh5rFOuA=",
+        "lastModified": 1735381016,
+        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83ecd50915a09dca928971139d3a102377a8d242",
+        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1731941836,
-        "narHash": "sha256-zpmAzrvK8KdssBSwiIwwRxaUJ77oWORbW0XFvgCFpTE=",
+        "lastModified": 1734994463,
+        "narHash": "sha256-S9MgfQjNt4J3I7obdLOVY23h+Yl/hnyibwGfOl+1uOE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "2f48272f34174fd2a5ab3df4d8a46919247be879",
+        "rev": "93e6f0d77548be8757c11ebda5c4235ef4f3bc67",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {
@@ -288,11 +288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730601085,
-        "narHash": "sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4=",
+        "lastModified": 1731897198,
+        "narHash": "sha256-Ou7vLETSKwmE/HRQz4cImXXJBr/k9gp4J4z/PF8LzTE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8d1b40f8dfd7539aaa3de56e207e22b3cc451825",
+        "rev": "0be641045af6d8666c11c2c40e45ffc9667839b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/a08bfe06b39e94eec98dd089a2c1b18af01fef19?narHash=sha256-b7G8oFp0Nj01BYUJ6ENC9Qf/HsYAIZvN9k/p0Kg/PFU%3D' (2024-12-16)
  → 'github:nix-community/disko/84a5b93637cc16cbfcc61b6e1684d626df61eb21?narHash=sha256-2dt1nOe9zf9pDkf5Kn7FUFyPRo581s0n90jxYXJ94l0%3D' (2024-12-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/83ecd50915a09dca928971139d3a102377a8d242?narHash=sha256-wNX3hsScqDdqKWOO87wETUEi7a/QlPVgpC/Lh5rFOuA%3D' (2024-12-16)
  → 'github:nix-community/home-manager/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2?narHash=sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4%3D' (2024-12-28)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/2f48272f34174fd2a5ab3df4d8a46919247be879?narHash=sha256-zpmAzrvK8KdssBSwiIwwRxaUJ77oWORbW0XFvgCFpTE%3D' (2024-11-18)
  → 'github:nix-community/lanzaboote/93e6f0d77548be8757c11ebda5c4235ef4f3bc67?narHash=sha256-S9MgfQjNt4J3I7obdLOVY23h%2BYl/hnyibwGfOl%2B1uOE%3D' (2024-12-23)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/a4ca93905455c07cb7e3aca95d4faf7601cba458?narHash=sha256-%2BXVYfmVXAiYA0FZT7ijHf555dxCe%2BAoAT5A6RU%2B6vSo%3D' (2024-11-03)
  → 'github:ipetkov/crane/ef80ead953c1b28316cc3f8613904edc2eb90c28?narHash=sha256-HQkYvKvaLQqNa10KEFGgWHfMAbWBfFp%2B4cAgkut%2BNNE%3D' (2024-11-08)
• Updated input 'lanzaboote/pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf?narHash=sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU%3D' (2024-10-30)
  → 'github:cachix/pre-commit-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0?narHash=sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf%2BInnSMT4jlMU%3D' (2024-11-11)
• Updated input 'lanzaboote/pre-commit-hooks-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7?narHash=sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo%3D' (2024-07-07)
  → 'github:NixOS/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3?narHash=sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo%3D' (2024-11-04)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/8d1b40f8dfd7539aaa3de56e207e22b3cc451825?narHash=sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4%3D' (2024-11-03)
  → 'github:oxalica/rust-overlay/0be641045af6d8666c11c2c40e45ffc9667839b5?narHash=sha256-Ou7vLETSKwmE/HRQz4cImXXJBr/k9gp4J4z/PF8LzTE%3D' (2024-11-18)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3566ab7246670a43abd2ffa913cc62dad9cdf7d5?narHash=sha256-AKU6qqskl0yf2%2BJdRdD0cfxX4b9x3KKV5RqA6wijmPM%3D' (2024-12-13)
  → 'github:nixos/nixpkgs/88195a94f390381c6afcdaa933c2f6ff93959cb4?narHash=sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs%3D' (2024-12-29)
```