### PR TITLE
fix(framework): rm deprecated pulseaudio

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -166,7 +166,6 @@
 
   hardware.cpu.amd.updateMicrocode = true;
   hardware.enableAllFirmware = true;
-  hardware.pulseaudio.enable = false;
   hardware.sensor.iio.enable = false;
 
   i18n.defaultLocale = "en_GB.UTF-8";


### PR DESCRIPTION
> The default sound server for most graphical sessions has been switched from PulseAudio to PipeWire. Users that want to keep using PulseAudio will want to set services.pipewire.enable = false; and hardware.pulseaudio.enable = true;. There is currently no plan to fully deprecate and remove PulseAudio, however, PipeWire should generally be preferred for new installs.

[skip ci]
