### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736437680,
-        "narHash": "sha256-9Sy17XguKdEU9M5peTrkWSlI/O5IAqjHzdzxbXnc30g=",
+        "lastModified": 1736711425,
+        "narHash": "sha256-8hKhPQuMtXfJi+4lPvw3FBk/zSJVHeb726Zo0uF1PP8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4d5d07d37ff773338e40a92088f45f4f88e509c8",
+        "rev": "f720e64ec37fa16ebba6354eadf310f81555cc07",
         "type": "github"
       },
       "original": {
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "lastModified": 1736523798,
+        "narHash": "sha256-Xb8mke6UCYjge9kPR9o4P1nVrhk7QBbKv3xQ9cj7h2s=",
         "ref": "nixos-unstable",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "rev": "130595eba61081acde9001f43de3248d8888ac4a",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/4d5d07d37ff773338e40a92088f45f4f88e509c8?narHash=sha256-9Sy17XguKdEU9M5peTrkWSlI/O5IAqjHzdzxbXnc30g%3D' (2025-01-09)
  → 'github:nix-community/disko/f720e64ec37fa16ebba6354eadf310f81555cc07?narHash=sha256-8hKhPQuMtXfJi%2B4lPvw3FBk/zSJVHeb726Zo0uF1PP8%3D' (2025-01-12)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=bffc22eb12172e6db3c5dde9e3e5628f8e3e7912&shallow=1' (2025-01-08)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=130595eba61081acde9001f43de3248d8888ac4a&shallow=1' (2025-01-10)
```