### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1737221749,
-        "narHash": "sha256-igllW0yG+UbetvhT11jnt9RppSHXYgMykYhZJeqfHs0=",
+        "lastModified": 1737480538,
+        "narHash": "sha256-rk/cmrvq3In0TegW9qaAxw+5YpJhRWt2p74/6JStrw0=",
         "ref": "master",
-        "rev": "97d7946b5e107dd03cc82f21165251d4e0159655",
+        "rev": "4481a16d1ac5bff4a77c608cefe08c9b9efe840d",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -187,11 +187,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1734994463,
-        "narHash": "sha256-S9MgfQjNt4J3I7obdLOVY23h+Yl/hnyibwGfOl+1uOE=",
+        "lastModified": 1737299073,
+        "narHash": "sha256-hOydnO9trHDo3qURqLSDdmE/pHNWDzlhkmyZ/gcBX2s=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "93e6f0d77548be8757c11ebda5c4235ef4f3bc67",
+        "rev": "64d20cb2afaad8b73f4e38de41d27fb30a782bb5",
         "type": "github"
       },
       "original": {
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1737469691,
+        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
         "ref": "nixos-unstable",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=97d7946b5e107dd03cc82f21165251d4e0159655&shallow=1' (2025-01-18)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=4481a16d1ac5bff4a77c608cefe08c9b9efe840d&shallow=1' (2025-01-21)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/93e6f0d77548be8757c11ebda5c4235ef4f3bc67?narHash=sha256-S9MgfQjNt4J3I7obdLOVY23h%2BYl/hnyibwGfOl%2B1uOE%3D' (2024-12-23)
  → 'github:nix-community/lanzaboote/64d20cb2afaad8b73f4e38de41d27fb30a782bb5?narHash=sha256-hOydnO9trHDo3qURqLSDdmE/pHNWDzlhkmyZ/gcBX2s%3D' (2025-01-19)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=5df43628fdf08d642be8ba5b3625a6c70731c19c&shallow=1' (2025-01-16)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab&shallow=1' (2025-01-21)
```