### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1737480538,
-        "narHash": "sha256-rk/cmrvq3In0TegW9qaAxw+5YpJhRWt2p74/6JStrw0=",
+        "lastModified": 1737630279,
+        "narHash": "sha256-wJQCxyMRc4P26zDrHmZiRD5bbfcJpqPG3e2djdGG3pk=",
         "ref": "master",
-        "rev": "4481a16d1ac5bff4a77c608cefe08c9b9efe840d",
+        "rev": "0db5c8bfcce78583ebbde0b2abbc95ad93445f7c",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=4481a16d1ac5bff4a77c608cefe08c9b9efe840d&shallow=1' (2025-01-21)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=0db5c8bfcce78583ebbde0b2abbc95ad93445f7c&shallow=1' (2025-01-23)
```