### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737038063,
-        "narHash": "sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk=",
+        "lastModified": 1738148035,
+        "narHash": "sha256-KYOATYEwaKysL3HdHdS5kbQMXvzS4iPJzJrML+3TKAo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "bf0abfde48f469c256f2b0f481c6281ff04a5db2",
+        "rev": "18d0a984cc2bc82cf61df19523a34ad463aa7f54",
         "type": "github"
       },
       "original": {
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1737480538,
-        "narHash": "sha256-rk/cmrvq3In0TegW9qaAxw+5YpJhRWt2p74/6JStrw0=",
+        "lastModified": 1738610386,
+        "narHash": "sha256-yb6a5efA1e8xze1vcdN2HBxqYr340EsxFMrDUHL3WZM=",
         "ref": "master",
-        "rev": "4481a16d1ac5bff4a77c608cefe08c9b9efe840d",
+        "rev": "066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -187,11 +187,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1737299073,
-        "narHash": "sha256-hOydnO9trHDo3qURqLSDdmE/pHNWDzlhkmyZ/gcBX2s=",
+        "lastModified": 1737639419,
+        "narHash": "sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "64d20cb2afaad8b73f4e38de41d27fb30a782bb5",
+        "rev": "a65905a09e2c43ff63be8c0e86a93712361f871e",
         "type": "github"
       },
       "original": {
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1738546358,
+        "narHash": "sha256-nLivjIygCiqLp5QcL7l56Tca/elVqM9FG1hGd9ZSsrg=",
         "ref": "nixos-unstable",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "c6e957d81b96751a3d5967a0fd73694f303cc914",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/bf0abfde48f469c256f2b0f481c6281ff04a5db2?narHash=sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk%3D' (2025-01-16)
  → 'github:nix-community/disko/18d0a984cc2bc82cf61df19523a34ad463aa7f54?narHash=sha256-KYOATYEwaKysL3HdHdS5kbQMXvzS4iPJzJrML%2B3TKAo%3D' (2025-01-29)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=4481a16d1ac5bff4a77c608cefe08c9b9efe840d&shallow=1' (2025-01-21)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe&shallow=1' (2025-02-03)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/64d20cb2afaad8b73f4e38de41d27fb30a782bb5?narHash=sha256-hOydnO9trHDo3qURqLSDdmE/pHNWDzlhkmyZ/gcBX2s%3D' (2025-01-19)
  → 'github:nix-community/lanzaboote/a65905a09e2c43ff63be8c0e86a93712361f871e?narHash=sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU%3D' (2025-01-23)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab&shallow=1' (2025-01-21)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=c6e957d81b96751a3d5967a0fd73694f303cc914&shallow=1' (2025-02-03)
```