### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738148035,
-        "narHash": "sha256-KYOATYEwaKysL3HdHdS5kbQMXvzS4iPJzJrML+3TKAo=",
+        "lastModified": 1739760714,
+        "narHash": "sha256-SaGuzIQUTC2UPwX0aTm9W4aSEUcq3h6yZbi30piej2U=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "18d0a984cc2bc82cf61df19523a34ad463aa7f54",
+        "rev": "be1e4321c9fb3a4bc2c061dafcdb424937a74dad",
         "type": "github"
       },
       "original": {
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1738610386,
-        "narHash": "sha256-yb6a5efA1e8xze1vcdN2HBxqYr340EsxFMrDUHL3WZM=",
+        "lastModified": 1739756364,
+        "narHash": "sha256-r8RxE0W3uhJ6unzbIddWTAzrpP9tMnmbj0F+DF+CTSM=",
         "ref": "master",
-        "rev": "066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe",
+        "rev": "662fa98bf488daa82ce8dc2bc443872952065ab9",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -187,11 +187,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1737639419,
-        "narHash": "sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU=",
+        "lastModified": 1739186342,
+        "narHash": "sha256-2j+sln9RwQn+g7J4GmdFFgvqXnLkvWBNMaUzONlkzUE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "a65905a09e2c43ff63be8c0e86a93712361f871e",
+        "rev": "3bdeebbc484a09391c4f0ec8a37bb77809426660",
         "type": "github"
       },
       "original": {
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738546358,
-        "narHash": "sha256-nLivjIygCiqLp5QcL7l56Tca/elVqM9FG1hGd9ZSsrg=",
+        "lastModified": 1739580444,
+        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
         "ref": "nixos-unstable",
-        "rev": "c6e957d81b96751a3d5967a0fd73694f303cc914",
+        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/18d0a984cc2bc82cf61df19523a34ad463aa7f54?narHash=sha256-KYOATYEwaKysL3HdHdS5kbQMXvzS4iPJzJrML%2B3TKAo%3D' (2025-01-29)
  → 'github:nix-community/disko/be1e4321c9fb3a4bc2c061dafcdb424937a74dad?narHash=sha256-SaGuzIQUTC2UPwX0aTm9W4aSEUcq3h6yZbi30piej2U%3D' (2025-02-17)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe&shallow=1' (2025-02-03)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=662fa98bf488daa82ce8dc2bc443872952065ab9&shallow=1' (2025-02-17)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/a65905a09e2c43ff63be8c0e86a93712361f871e?narHash=sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU%3D' (2025-01-23)
  → 'github:nix-community/lanzaboote/3bdeebbc484a09391c4f0ec8a37bb77809426660?narHash=sha256-2j%2Bsln9RwQn%2Bg7J4GmdFFgvqXnLkvWBNMaUzONlkzUE%3D' (2025-02-10)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=c6e957d81b96751a3d5967a0fd73694f303cc914&shallow=1' (2025-02-03)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=8bb37161a0488b89830168b81c48aed11569cb93&shallow=1' (2025-02-15)
```