### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739760714,
-        "narHash": "sha256-SaGuzIQUTC2UPwX0aTm9W4aSEUcq3h6yZbi30piej2U=",
+        "lastModified": 1739841949,
+        "narHash": "sha256-lSOXdgW/1zi/SSu7xp71v+55D5Egz8ACv0STkj7fhbs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "be1e4321c9fb3a4bc2c061dafcdb424937a74dad",
+        "rev": "15dbf8cebd8e2655a883b74547108e089f051bf0",
         "type": "github"
       },
       "original": {
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1739756364,
-        "narHash": "sha256-r8RxE0W3uhJ6unzbIddWTAzrpP9tMnmbj0F+DF+CTSM=",
+        "lastModified": 1739913864,
+        "narHash": "sha256-WhzgQjadrwnwPJQLLxZUUEIxojxa7UWDkf7raAkB1Lw=",
         "ref": "master",
-        "rev": "662fa98bf488daa82ce8dc2bc443872952065ab9",
+        "rev": "97ac0801d187b2911e8caa45316399de12f6f199",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739580444,
-        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "ref": "nixos-unstable",
-        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/be1e4321c9fb3a4bc2c061dafcdb424937a74dad?narHash=sha256-SaGuzIQUTC2UPwX0aTm9W4aSEUcq3h6yZbi30piej2U%3D' (2025-02-17)
  → 'github:nix-community/disko/15dbf8cebd8e2655a883b74547108e089f051bf0?narHash=sha256-lSOXdgW/1zi/SSu7xp71v%2B55D5Egz8ACv0STkj7fhbs%3D' (2025-02-18)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=662fa98bf488daa82ce8dc2bc443872952065ab9&shallow=1' (2025-02-17)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=97ac0801d187b2911e8caa45316399de12f6f199&shallow=1' (2025-02-18)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=8bb37161a0488b89830168b81c48aed11569cb93&shallow=1' (2025-02-15)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=73cf49b8ad837ade2de76f87eb53fc85ed5d4680&shallow=1' (2025-02-18)
```