### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739841949,
-        "narHash": "sha256-lSOXdgW/1zi/SSu7xp71v+55D5Egz8ACv0STkj7fhbs=",
+        "lastModified": 1740485968,
+        "narHash": "sha256-WK+PZHbfDjLyveXAxpnrfagiFgZWaTJglewBWniTn2Y=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "15dbf8cebd8e2655a883b74547108e089f051bf0",
+        "rev": "19c1140419c4f1cdf88ad4c1cfb6605597628940",
         "type": "github"
       },
       "original": {
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1739913864,
-        "narHash": "sha256-WhzgQjadrwnwPJQLLxZUUEIxojxa7UWDkf7raAkB1Lw=",
+        "lastModified": 1740845322,
+        "narHash": "sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw=",
         "ref": "master",
-        "rev": "97ac0801d187b2911e8caa45316399de12f6f199",
+        "rev": "fcac3d6d88302a5e64f6cb8014ac785e08874c8d",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -187,11 +187,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1739186342,
-        "narHash": "sha256-2j+sln9RwQn+g7J4GmdFFgvqXnLkvWBNMaUzONlkzUE=",
+        "lastModified": 1740440383,
+        "narHash": "sha256-w8ixbqOGrVWMQZFFs4uAwZpuwuGMzFoKjocMFxTR5Ts=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "3bdeebbc484a09391c4f0ec8a37bb77809426660",
+        "rev": "6321bc060d757c137c1fbae2057c7e941483878f",
         "type": "github"
       },
       "original": {
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739866667,
-        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "lastModified": 1740828860,
+        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
         "ref": "nixos-unstable",
-        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/15dbf8cebd8e2655a883b74547108e089f051bf0?narHash=sha256-lSOXdgW/1zi/SSu7xp71v%2B55D5Egz8ACv0STkj7fhbs%3D' (2025-02-18)
  → 'github:nix-community/disko/19c1140419c4f1cdf88ad4c1cfb6605597628940?narHash=sha256-WK%2BPZHbfDjLyveXAxpnrfagiFgZWaTJglewBWniTn2Y%3D' (2025-02-25)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=97ac0801d187b2911e8caa45316399de12f6f199&shallow=1' (2025-02-18)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=fcac3d6d88302a5e64f6cb8014ac785e08874c8d&shallow=1' (2025-03-01)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/3bdeebbc484a09391c4f0ec8a37bb77809426660?narHash=sha256-2j%2Bsln9RwQn%2Bg7J4GmdFFgvqXnLkvWBNMaUzONlkzUE%3D' (2025-02-10)
  → 'github:nix-community/lanzaboote/6321bc060d757c137c1fbae2057c7e941483878f?narHash=sha256-w8ixbqOGrVWMQZFFs4uAwZpuwuGMzFoKjocMFxTR5Ts%3D' (2025-02-24)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=73cf49b8ad837ade2de76f87eb53fc85ed5d4680&shallow=1' (2025-02-18)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=303bd8071377433a2d8f76e684ec773d70c5b642&shallow=1' (2025-03-01)
```