### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741684000,
-        "narHash": "sha256-NQykaWIrn5zilncefIvW4jPQ76YMXVK/dMTzkSVDmdk=",
+        "lastModified": 1741786315,
+        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "2db1d64fc084b1d15e3871dffc02c62a94ed6ed7",
+        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
         "type": "github"
       },
       "original": {
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1741701235,
-        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
+        "lastModified": 1741955947,
+        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
         "ref": "master",
-        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
+        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1742069588,
+        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
         "ref": "nixos-unstable",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/2db1d64fc084b1d15e3871dffc02c62a94ed6ed7?narHash=sha256-NQykaWIrn5zilncefIvW4jPQ76YMXVK/dMTzkSVDmdk%3D' (2025-03-11)
  → 'github:nix-community/disko/0d8c6ad4a43906d14abd5c60e0ffe7b587b213de?narHash=sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc%3D' (2025-03-12)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=c630dfa8abcc65984cc1e47fb25d4552c81dd37e&shallow=1' (2025-03-11)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=4e12151c9e014e2449e0beca2c0e9534b96a26b4&shallow=1' (2025-03-14)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=e3e32b642a31e6714ec1b712de8c91a3352ce7e1&shallow=1' (2025-03-09)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5&shallow=1' (2025-03-15)
```