### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741786315,
-        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
+        "lastModified": 1743598667,
+        "narHash": "sha256-ViE7NoFWytYO2uJONTAX35eGsvTYXNHjWALeHAg8OQY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
+        "rev": "329d3d7e8bc63dd30c39e14e6076db590a6eabe6",
         "type": "github"
       },
       "original": {
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1742996658,
-        "narHash": "sha256-snxgTLVq6ooaD3W3mPHu7LVWpoZKczhxHAUZy2ea4oA=",
+        "lastModified": 1743717835,
+        "narHash": "sha256-LJm6FoIcUoBw3w25ty12/sBfut4zZuNGdN0phYj/ekU=",
         "ref": "master",
-        "rev": "693840c01b9bef9e54100239cef937e53d4661bf",
+        "rev": "66a6ec65f84255b3defb67ff45af86c844dd451b",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "ref": "nixos-unstable",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/0d8c6ad4a43906d14abd5c60e0ffe7b587b213de?narHash=sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc%3D' (2025-03-12)
  → 'github:nix-community/disko/329d3d7e8bc63dd30c39e14e6076db590a6eabe6?narHash=sha256-ViE7NoFWytYO2uJONTAX35eGsvTYXNHjWALeHAg8OQY%3D' (2025-04-02)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=693840c01b9bef9e54100239cef937e53d4661bf&shallow=1' (2025-03-26)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=66a6ec65f84255b3defb67ff45af86c844dd451b&shallow=1' (2025-04-03)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=698214a32beb4f4c8e3942372c694f40848b360d&shallow=1' (2025-03-25)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=2c8d3f48d33929642c1c12cd243df4cc7d2ce434&shallow=1' (2025-04-02)
```