### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743598667,
-        "narHash": "sha256-ViE7NoFWytYO2uJONTAX35eGsvTYXNHjWALeHAg8OQY=",
+        "lastModified": 1744145203,
+        "narHash": "sha256-I2oILRiJ6G+BOSjY+0dGrTPe080L3pbKpc+gCV3Nmyk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "329d3d7e8bc63dd30c39e14e6076db590a6eabe6",
+        "rev": "76c0a6dba345490508f36c1aa3c7ba5b6b460989",
         "type": "github"
       },
       "original": {
@@ -160,10 +160,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1743717835,
-        "narHash": "sha256-LJm6FoIcUoBw3w25ty12/sBfut4zZuNGdN0phYj/ekU=",
+        "lastModified": 1744600951,
+        "narHash": "sha256-LNAAfQTDXSwtYYlh/v/tMwnCqeQAEHlBC9PgyQK5b/Q=",
         "ref": "master",
-        "rev": "66a6ec65f84255b3defb67ff45af86c844dd451b",
+        "rev": "e980d0e0e216f527ea73cfd12c7b019eceffa7f1",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -202,10 +202,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "ref": "nixos-unstable",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/329d3d7e8bc63dd30c39e14e6076db590a6eabe6?narHash=sha256-ViE7NoFWytYO2uJONTAX35eGsvTYXNHjWALeHAg8OQY%3D' (2025-04-02)
  → 'github:nix-community/disko/76c0a6dba345490508f36c1aa3c7ba5b6b460989?narHash=sha256-I2oILRiJ6G%2BBOSjY%2B0dGrTPe080L3pbKpc%2BgCV3Nmyk%3D' (2025-04-08)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=66a6ec65f84255b3defb67ff45af86c844dd451b&shallow=1' (2025-04-03)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=e980d0e0e216f527ea73cfd12c7b019eceffa7f1&shallow=1' (2025-04-14)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=2c8d3f48d33929642c1c12cd243df4cc7d2ce434&shallow=1' (2025-04-02)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=2631b0b7abcea6e640ce31cd78ea58910d31e650&shallow=1' (2025-04-12)
```