### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1745630506,
-        "narHash": "sha256-bHCFgGeu8XjWlVuaWzi3QONjDW3coZDqSHvnd4l7xus=",
+        "lastModified": 1747514353,
+        "narHash": "sha256-E1WjB+zvDw4x058mg3MIdK5j2huvnNpTEEt2brhg2H8=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "96e078c646b711aee04b82ba01aefbff87004ded",
+        "rev": "6697e8babbd8f323dfd5e28f160a0128582c128b",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723809819,
-        "narHash": "sha256-XnTbkn9Hcb1+Z+GL/tNyJmj1ZGxsaU8GAlpnFeCUPdo=",
+        "lastModified": 1747566860,
+        "narHash": "sha256-5X0I6frW/GP5WlK+DQaTBCZsP8p0DLG/GtiR+1y8gYc=",
         "owner": "tlvince",
         "repo": "apple-fonts.nix",
-        "rev": "3323f627bc86c32a329f3134b0a023c4a9960a8f",
+        "rev": "94d3ca1c45cd838ef46f7137bb8afabc70a41cb6",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746729224,
-        "narHash": "sha256-9R4sOLAK1w3Bq54H3XOJogdc7a6C2bLLmatOQ+5pf5w=",
+        "lastModified": 1747274630,
+        "narHash": "sha256-87RJwXbfOHyzTB9LYagAQ6vOZhszCvd8Gvudu+gf3qo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "85555d27ded84604ad6657ecca255a03fd878607",
+        "rev": "ec7c109a4f794fce09aad87239eab7f66540b888",
         "type": "github"
       },
       "original": {
@@ -226,10 +226,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1747021744,
-        "narHash": "sha256-IDsM/9/tHQBlhG3tXI2fTM84AUN1uRa7JDPT1LMlGes=",
+        "lastModified": 1747565775,
+        "narHash": "sha256-B6jmKHUEX1jxxcdoYHl7RVaeohtAVup8o3nuVkzkloA=",
         "ref": "master",
-        "rev": "fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52",
+        "rev": "97118a310eb8e13bc1b9b12d67267e55b7bee6c8",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -253,11 +253,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1746809399,
-        "narHash": "sha256-rMYfYaUpKuyMpDnodIfgFOnj6Wn0duItZvG4kQODcZo=",
+        "lastModified": 1747056319,
+        "narHash": "sha256-qSKcBaISBozadtPq6BomnD+wIYTZIkiua3UuHLaD52c=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "8f27abb5e623d83db4988ee3e864df48181e7c30",
+        "rev": "2e425f3da6ce7f5b34fa6eaf7a2a7f78dbabcc85",
         "type": "github"
       },
       "original": {
@@ -268,10 +268,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "ref": "nixos-unstable",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"
@@ -359,11 +359,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746671794,
-        "narHash": "sha256-V+mpk2frYIEm85iYf+KPDmCGG3zBRAEhbv0E3lHdG2U=",
+        "lastModified": 1747017456,
+        "narHash": "sha256-C/U12fcO+HEF071b5mK65lt4XtAIZyJSSJAg9hdlvTk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ceec434b8741c66bb8df5db70d7e629a9d9c598f",
+        "rev": "5b07506ae89b025b14de91f697eba23b48654c52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'agenix':
    'github:ryantm/agenix/96e078c646b711aee04b82ba01aefbff87004ded?narHash=sha256-bHCFgGeu8XjWlVuaWzi3QONjDW3coZDqSHvnd4l7xus%3D' (2025-04-26)
  → 'github:ryantm/agenix/6697e8babbd8f323dfd5e28f160a0128582c128b?narHash=sha256-E1WjB%2BzvDw4x058mg3MIdK5j2huvnNpTEEt2brhg2H8%3D' (2025-05-17)
• Updated input 'apple-fonts':
    'github:tlvince/apple-fonts.nix/3323f627bc86c32a329f3134b0a023c4a9960a8f?narHash=sha256-XnTbkn9Hcb1%2BZ%2BGL/tNyJmj1ZGxsaU8GAlpnFeCUPdo%3D' (2024-08-16)
  → 'github:tlvince/apple-fonts.nix/94d3ca1c45cd838ef46f7137bb8afabc70a41cb6?narHash=sha256-5X0I6frW/GP5WlK%2BDQaTBCZsP8p0DLG/GtiR%2B1y8gYc%3D' (2025-05-18)
• Updated input 'disko':
    'github:nix-community/disko/85555d27ded84604ad6657ecca255a03fd878607?narHash=sha256-9R4sOLAK1w3Bq54H3XOJogdc7a6C2bLLmatOQ%2B5pf5w%3D' (2025-05-08)
  → 'github:nix-community/disko/ec7c109a4f794fce09aad87239eab7f66540b888?narHash=sha256-87RJwXbfOHyzTB9LYagAQ6vOZhszCvd8Gvudu%2Bgf3qo%3D' (2025-05-15)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52&shallow=1' (2025-05-12)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=97118a310eb8e13bc1b9b12d67267e55b7bee6c8&shallow=1' (2025-05-18)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/8f27abb5e623d83db4988ee3e864df48181e7c30?narHash=sha256-rMYfYaUpKuyMpDnodIfgFOnj6Wn0duItZvG4kQODcZo%3D' (2025-05-09)
  → 'github:nix-community/lanzaboote/2e425f3da6ce7f5b34fa6eaf7a2a7f78dbabcc85?narHash=sha256-qSKcBaISBozadtPq6BomnD%2BwIYTZIkiua3UuHLaD52c%3D' (2025-05-12)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/ceec434b8741c66bb8df5db70d7e629a9d9c598f?narHash=sha256-V%2Bmpk2frYIEm85iYf%2BKPDmCGG3zBRAEhbv0E3lHdG2U%3D' (2025-05-08)
  → 'github:oxalica/rust-overlay/5b07506ae89b025b14de91f697eba23b48654c52?narHash=sha256-C/U12fcO%2BHEF071b5mK65lt4XtAIZyJSSJAg9hdlvTk%3D' (2025-05-12)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=d89fc19e405cb2d55ce7cc114356846a0ee5e956&shallow=1' (2025-05-10)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=e06158e58f3adee28b139e9c2bcfcc41f8625b46&shallow=1' (2025-05-15)
```