### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747514353,
-        "narHash": "sha256-E1WjB+zvDw4x058mg3MIdK5j2huvnNpTEEt2brhg2H8=",
+        "lastModified": 1747575206,
+        "narHash": "sha256-NwmAFuDUO/PFcgaGGr4j3ozG9Pe5hZ/ogitWhY+D81k=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "6697e8babbd8f323dfd5e28f160a0128582c128b",
+        "rev": "4835b1dc898959d8547a871ef484930675cb47f1",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747274630,
-        "narHash": "sha256-87RJwXbfOHyzTB9LYagAQ6vOZhszCvd8Gvudu+gf3qo=",
+        "lastModified": 1747621015,
+        "narHash": "sha256-j0fo1rNxZvmFLMaE945UrbLJZAHTlQmq0/QMgOP4GTs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "ec7c109a4f794fce09aad87239eab7f66540b888",
+        "rev": "cec44d77d9dacf0c91d3d51aff128fefabce06ee",
         "type": "github"
       },
       "original": {
@@ -229,10 +229,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "ref": "nixos-unstable",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'agenix':
    'github:ryantm/agenix/6697e8babbd8f323dfd5e28f160a0128582c128b?narHash=sha256-E1WjB%2BzvDw4x058mg3MIdK5j2huvnNpTEEt2brhg2H8%3D' (2025-05-17)
  → 'github:ryantm/agenix/4835b1dc898959d8547a871ef484930675cb47f1?narHash=sha256-NwmAFuDUO/PFcgaGGr4j3ozG9Pe5hZ/ogitWhY%2BD81k%3D' (2025-05-18)
• Updated input 'disko':
    'github:nix-community/disko/ec7c109a4f794fce09aad87239eab7f66540b888?narHash=sha256-87RJwXbfOHyzTB9LYagAQ6vOZhszCvd8Gvudu%2Bgf3qo%3D' (2025-05-15)
  → 'github:nix-community/disko/cec44d77d9dacf0c91d3d51aff128fefabce06ee?narHash=sha256-j0fo1rNxZvmFLMaE945UrbLJZAHTlQmq0/QMgOP4GTs%3D' (2025-05-19)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=e06158e58f3adee28b139e9c2bcfcc41f8625b46&shallow=1' (2025-05-15)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=292fa7d4f6519c074f0a50394dbbe69859bb6043&shallow=1' (2025-05-18)
```