### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,10 +187,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1747875884,
-        "narHash": "sha256-tdVx4kghhdy62LKuTnwE2RytOe8o88tah/yhpyuL0D4=",
+        "lastModified": 1747978958,
+        "narHash": "sha256-pQQnbxWpY3IiZqgelXHIe/OAE/Yv4NSQq7fch7M6nXQ=",
         "ref": "master",
-        "rev": "f9186c64fcc6ee5f0114547acf9e814c806a640b",
+        "rev": "7419250703fd5eb50e99bdfb07a86671939103ea",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=f9186c64fcc6ee5f0114547acf9e814c806a640b&shallow=1' (2025-05-22)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=7419250703fd5eb50e99bdfb07a86671939103ea&shallow=1' (2025-05-23)
```