### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,10 +167,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1748391243,
-        "narHash": "sha256-7sCuihzsTRZemtbTXaFUoGJUfuQErhKEcL9v7HKIo1k=",
+        "lastModified": 1748489961,
+        "narHash": "sha256-uGnudxMoQi2c8rpPoHXuQSm80NBqlOiNF4xdT3hhzLM=",
         "ref": "master",
-        "rev": "f5b12be834874f7661db4ced969a621ab2d57971",
+        "rev": "95c988cf08e9a5a8fe7cc275d5e3f24e9e87bd51",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=f5b12be834874f7661db4ced969a621ab2d57971&shallow=1' (2025-05-28)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=95c988cf08e9a5a8fe7cc275d5e3f24e9e87bd51&shallow=1' (2025-05-29)
```