### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,10 +167,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1748489961,
-        "narHash": "sha256-uGnudxMoQi2c8rpPoHXuQSm80NBqlOiNF4xdT3hhzLM=",
+        "lastModified": 1748570847,
+        "narHash": "sha256-XU1a6wFctd+s3ZvBIFB6s4GhPJ+Oc6pkeOrEsbA2fMo=",
         "ref": "master",
-        "rev": "95c988cf08e9a5a8fe7cc275d5e3f24e9e87bd51",
+        "rev": "4e9efaa68b0be7e19127dad4f0506a9b89e28ef4",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=95c988cf08e9a5a8fe7cc275d5e3f24e9e87bd51&shallow=1' (2025-05-29)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=4e9efaa68b0be7e19127dad4f0506a9b89e28ef4&shallow=1' (2025-05-30)
```