### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748225455,
-        "narHash": "sha256-AzlJCKaM4wbEyEpV3I/PUq5mHnib2ryEy32c+qfj6xk=",
+        "lastModified": 1748832438,
+        "narHash": "sha256-/CtyLVfNaFP7PrOPrTEuGOJBIhcBKVQ91KiEbtXJi0A=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a894f2811e1ee8d10c50560551e50d6ab3c392ba",
+        "rev": "58d6e5a83fff9982d57e0a0a994d4e5c0af441e4",
         "type": "github"
       },
       "original": {
@@ -167,10 +167,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1748627197,
-        "narHash": "sha256-7dTtcq4Yi78cHfZcJaxlqkNs+cDBotrHjR9mkXfiUz4=",
+        "lastModified": 1748925027,
+        "narHash": "sha256-BJ0qRIdvt5aeqm3zg/5if7b5rruG05zrSX3UpLqjDRk=",
         "ref": "master",
-        "rev": "379c9fb858ef9abe92d5590e7502a7c1387c076a",
+        "rev": "cb809ec1ff15cf3237c6592af9bbc7e4d983e98c",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -209,10 +209,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748460289,
-        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
         "ref": "nixos-unstable",
-        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/a894f2811e1ee8d10c50560551e50d6ab3c392ba?narHash=sha256-AzlJCKaM4wbEyEpV3I/PUq5mHnib2ryEy32c%2Bqfj6xk%3D' (2025-05-26)
  → 'github:nix-community/disko/58d6e5a83fff9982d57e0a0a994d4e5c0af441e4?narHash=sha256-/CtyLVfNaFP7PrOPrTEuGOJBIhcBKVQ91KiEbtXJi0A%3D' (2025-06-02)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=379c9fb858ef9abe92d5590e7502a7c1387c076a&shallow=1' (2025-05-30)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=cb809ec1ff15cf3237c6592af9bbc7e4d983e98c&shallow=1' (2025-06-03)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=96ec055edbe5ee227f28cdbc3f1ddf1df5965102&shallow=1' (2025-05-28)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=910796cabe436259a29a72e8d3f5e180fc6dfacc&shallow=1' (2025-05-31)
```