### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,10 +167,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1749657191,
-        "narHash": "sha256-QLilaHuhGxiwhgceDWESj9gFcKIdEp7+9lRqNGpN8S4=",
+        "lastModified": 1749821119,
+        "narHash": "sha256-X3WAS322EsebI4ohJcXhKpiyG1v+7wE4VOiXy1pxM/c=",
         "ref": "master",
-        "rev": "faeab32528a9360e9577ff4082de2d35c6bbe1ce",
+        "rev": "79dfd9aa295e53773aad45480b44c131da29f35b",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -209,10 +209,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1749794982,
+        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
         "ref": "nixos-unstable",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=faeab32528a9360e9577ff4082de2d35c6bbe1ce&shallow=1' (2025-06-11)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=79dfd9aa295e53773aad45480b44c131da29f35b&shallow=1' (2025-06-13)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=3e3afe5174c561dee0df6f2c2b2236990146329f&shallow=1' (2025-06-07)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=ee930f9755f58096ac6e8ca94a1887e0534e2d81&shallow=1' (2025-06-13)
```