### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747575206,
-        "narHash": "sha256-NwmAFuDUO/PFcgaGGr4j3ozG9Pe5hZ/ogitWhY+D81k=",
+        "lastModified": 1750173260,
+        "narHash": "sha256-9P1FziAwl5+3edkfFcr5HeGtQUtrSdk/MksX39GieoA=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "4835b1dc898959d8547a871ef484930675cb47f1",
+        "rev": "531beac616433bac6f9e2a19feb8e99a22a66baf",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749436314,
-        "narHash": "sha256-CqmqU5FRg5AadtIkxwu8ulDSOSoIisUMZRLlcED3Q5w=",
+        "lastModified": 1750040002,
+        "narHash": "sha256-KrC9iOVYIn6ukpVlHbqSA4hYCZ6oDyJKrcLqv4c5v84=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "dfa4d1b9c39c0342ef133795127a3af14598017a",
+        "rev": "7f1857b31522062a6a00f88cbccf86b43acceed1",
         "type": "github"
       },
       "original": {
@@ -167,10 +167,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1749821119,
-        "narHash": "sha256-X3WAS322EsebI4ohJcXhKpiyG1v+7wE4VOiXy1pxM/c=",
+        "lastModified": 1750304462,
+        "narHash": "sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc=",
         "ref": "master",
-        "rev": "79dfd9aa295e53773aad45480b44c131da29f35b",
+        "rev": "863842639722dd12ae9e37ca83bcb61a63b36f6c",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nix-community/home-manager"
@@ -194,11 +194,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1749471908,
-        "narHash": "sha256-uGfPqd43KTomeIVWUzHu3hGLWFsqYibhWLt2OaRic28=",
+        "lastModified": 1750168384,
+        "narHash": "sha256-PBfJ7dGsR02im/RYN8wXII8yNPFhKxiPdq+JDfbvD2k=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "00292388ad3b497763b81568d6ee5e1c4a2bcf85",
+        "rev": "38c2addd2e0cedcb03708de6e6c21fb1be86d410",
         "type": "github"
       },
       "original": {
@@ -209,10 +209,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749794982,
-        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
+        "lastModified": 1750134718,
+        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
         "ref": "nixos-unstable",
-        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
+        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"
@@ -237,11 +237,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747372754,
-        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
+        "lastModified": 1749636823,
+        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749436897,
-        "narHash": "sha256-OkDtaCGQQVwVFz5HWfbmrMJR99sFIMXHCHEYXzUJEJY=",
+        "lastModified": 1749955444,
+        "narHash": "sha256-CllTHvHX8KAdAZ+Lxzd23AmZTxO1Pfy+zC43/5tYkAE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e7876c387e35dc834838aff254d8e74cf5bd4f19",
+        "rev": "539ba15741f0e6691a2448743dbc601d8910edce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'agenix':
    'github:ryantm/agenix/4835b1dc898959d8547a871ef484930675cb47f1?narHash=sha256-NwmAFuDUO/PFcgaGGr4j3ozG9Pe5hZ/ogitWhY%2BD81k%3D' (2025-05-18)
  → 'github:ryantm/agenix/531beac616433bac6f9e2a19feb8e99a22a66baf?narHash=sha256-9P1FziAwl5%2B3edkfFcr5HeGtQUtrSdk/MksX39GieoA%3D' (2025-06-17)
• Updated input 'disko':
    'github:nix-community/disko/dfa4d1b9c39c0342ef133795127a3af14598017a?narHash=sha256-CqmqU5FRg5AadtIkxwu8ulDSOSoIisUMZRLlcED3Q5w%3D' (2025-06-09)
  → 'github:nix-community/disko/7f1857b31522062a6a00f88cbccf86b43acceed1?narHash=sha256-KrC9iOVYIn6ukpVlHbqSA4hYCZ6oDyJKrcLqv4c5v84%3D' (2025-06-16)
• Updated input 'home-manager':
    'git+https://github.com/nix-community/home-manager?ref=master&rev=79dfd9aa295e53773aad45480b44c131da29f35b&shallow=1' (2025-06-13)
  → 'git+https://github.com/nix-community/home-manager?ref=master&rev=863842639722dd12ae9e37ca83bcb61a63b36f6c&shallow=1' (2025-06-19)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/00292388ad3b497763b81568d6ee5e1c4a2bcf85?narHash=sha256-uGfPqd43KTomeIVWUzHu3hGLWFsqYibhWLt2OaRic28%3D' (2025-06-09)
  → 'github:nix-community/lanzaboote/38c2addd2e0cedcb03708de6e6c21fb1be86d410?narHash=sha256-PBfJ7dGsR02im/RYN8wXII8yNPFhKxiPdq%2BJDfbvD2k%3D' (2025-06-17)
• Updated input 'lanzaboote/pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/80479b6ec16fefd9c1db3ea13aeb038c60530f46?narHash=sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo%2BbnXU9D9k%3D' (2025-05-16)
  → 'github:cachix/pre-commit-hooks.nix/623c56286de5a3193aa38891a6991b28f9bab056?narHash=sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4%3D' (2025-06-11)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/e7876c387e35dc834838aff254d8e74cf5bd4f19?narHash=sha256-OkDtaCGQQVwVFz5HWfbmrMJR99sFIMXHCHEYXzUJEJY%3D' (2025-06-09)
  → 'github:oxalica/rust-overlay/539ba15741f0e6691a2448743dbc601d8910edce?narHash=sha256-CllTHvHX8KAdAZ%2BLxzd23AmZTxO1Pfy%2BzC43/5tYkAE%3D' (2025-06-15)
• Updated input 'nixpkgs':
    'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=ee930f9755f58096ac6e8ca94a1887e0534e2d81&shallow=1' (2025-06-13)
  → 'git+https://github.com/NixOS/nixpkgs?ref=nixos-unstable&rev=9e83b64f727c88a7711a2c463a7b16eedb69a84c&shallow=1' (2025-06-17)
```