### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,11 +167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755229570,
-        "narHash": "sha256-soZegto0xXzG2zYlu/zjknDHv0Z7tRS5EQs+Z/VRTBg=",
+        "lastModified": 1755313937,
+        "narHash": "sha256-pQb7bNcolxYGRiylUCrTddiF+qW2wsUiM9+eRIDUrVU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11626a4383b458f8dc5ea3237eaa04e8ab1912f3",
+        "rev": "2a749f4790a14f7168be67cdf6e548ef1c944e10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/11626a4383b458f8dc5ea3237eaa04e8ab1912f3?narHash=sha256-soZegto0xXzG2zYlu/zjknDHv0Z7tRS5EQs%2BZ/VRTBg%3D' (2025-08-15)
  → 'github:nix-community/home-manager/2a749f4790a14f7168be67cdf6e548ef1c944e10?narHash=sha256-pQb7bNcolxYGRiylUCrTddiF%2BqW2wsUiM9%2BeRIDUrVU%3D' (2025-08-16)
```