### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,11 +167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761191301,
-        "narHash": "sha256-xsRL2Oyb4YRZZ1Tu4WzR2uFg1n931bH+PfLdFcqtLg8=",
+        "lastModified": 1761530345,
+        "narHash": "sha256-+9+YCK9Lh6GThkXu/8JTxMFUnImIdZpb8ElUh6/F5Y8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4958aafe7b237dc1e857fb0c916efff72075048f",
+        "rev": "bbaeb9f1c29e79bb1653b32c3d73244cdf4bd888",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761114652,
-        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
+        "lastModified": 1761373498,
+        "narHash": "sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
+        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/4958aafe7b237dc1e857fb0c916efff72075048f?narHash=sha256-xsRL2Oyb4YRZZ1Tu4WzR2uFg1n931bH%2BPfLdFcqtLg8%3D' (2025-10-23)
  → 'github:nix-community/home-manager/bbaeb9f1c29e79bb1653b32c3d73244cdf4bd888?narHash=sha256-%2B9%2BYCK9Lh6GThkXu/8JTxMFUnImIdZpb8ElUh6/F5Y8%3D' (2025-10-27)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/01f116e4df6a15f4ccdffb1bcd41096869fb385c?narHash=sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d%2BdAiC3H%2BCDle4%3D' (2025-10-22)
  → 'github:nixos/nixpkgs/6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce?narHash=sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c%3D' (2025-10-25)
```