### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761899396,
-        "narHash": "sha256-XOpKBp6HLzzMCbzW50TEuXN35zN5WGQREC7n34DcNMM=",
+        "lastModified": 1762276996,
+        "narHash": "sha256-TtcPgPmp2f0FAnc+DMEw4ardEgv1SGNR3/WFGH0N19M=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "6f4cf5abbe318e4cd1e879506f6eeafd83f7b998",
+        "rev": "af087d076d3860760b3323f6b583f4d828c1ac17",
         "type": "github"
       },
       "original": {
@@ -167,11 +167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762228452,
-        "narHash": "sha256-Y5950vzoyJ8+u4U6dlI/2VEbf3JQnIJsmRWWWcsgpRg=",
+        "lastModified": 1762463325,
+        "narHash": "sha256-33YUsWpPyeBZEWrKQ2a1gkRZ7i0XCC/2MYpU6BVeQSU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aa6936bb637e46a49cf1292486200ba41dd4bcf7",
+        "rev": "0562fef070a1027325dd4ea10813d64d2c967b39",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762111121,
-        "narHash": "sha256-4vhDuZ7OZaZmKKrnDpxLZZpGIJvAeMtK6FKLJYUtAdw=",
+        "lastModified": 1762363567,
+        "narHash": "sha256-YRqMDEtSMbitIMj+JLpheSz0pwEr0Rmy5mC7myl17xs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+        "rev": "ae814fd3904b621d8ab97418f1d0f2eb0d3716f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/6f4cf5abbe318e4cd1e879506f6eeafd83f7b998?narHash=sha256-XOpKBp6HLzzMCbzW50TEuXN35zN5WGQREC7n34DcNMM%3D' (2025-10-31)
  → 'github:nix-community/disko/af087d076d3860760b3323f6b583f4d828c1ac17?narHash=sha256-TtcPgPmp2f0FAnc%2BDMEw4ardEgv1SGNR3/WFGH0N19M%3D' (2025-11-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/aa6936bb637e46a49cf1292486200ba41dd4bcf7?narHash=sha256-Y5950vzoyJ8%2Bu4U6dlI/2VEbf3JQnIJsmRWWWcsgpRg%3D' (2025-11-04)
  → 'github:nix-community/home-manager/0562fef070a1027325dd4ea10813d64d2c967b39?narHash=sha256-33YUsWpPyeBZEWrKQ2a1gkRZ7i0XCC/2MYpU6BVeQSU%3D' (2025-11-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b3d51a0365f6695e7dd5cdf3e180604530ed33b4?narHash=sha256-4vhDuZ7OZaZmKKrnDpxLZZpGIJvAeMtK6FKLJYUtAdw%3D' (2025-11-02)
  → 'github:nixos/nixpkgs/ae814fd3904b621d8ab97418f1d0f2eb0d3716f4?narHash=sha256-YRqMDEtSMbitIMj%2BJLpheSz0pwEr0Rmy5mC7myl17xs%3D' (2025-11-05)
```