### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1761645416,
-        "narHash": "sha256-wTQzbbQ6XHtvNJVuhJj+ytZDRyNtwUKbrIfIvMvKNfQ=",
+        "lastModified": 1763308703,
+        "narHash": "sha256-O9Y+Wer8wOh+N+4kcCK5p/VLrXyX+ktk0/s3HdZvJzk=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "633af1961cae8e02bc6195e6e599a6b09bf75217",
+        "rev": "5a9bba070f801d63e2af3c9ef00b86b212429f4f",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762964643,
-        "narHash": "sha256-RYHN8O/Aja59XDji6WSJZPkJpYVUfpSkyH+PEupBJqM=",
+        "lastModified": 1763313531,
+        "narHash": "sha256-yvdCYUL85zEDp2NzPUBmaNBXP6KnWEOhAk3j7PTfsKw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "827f2a23373a774a8805f84ca5344654c31f354b",
+        "rev": "3670a78eee49deebe4825fc8ecc46b172d1a8391",
         "type": "github"
       },
       "original": {
@@ -214,11 +214,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1762205063,
-        "narHash": "sha256-If6vQ+KvtKs3ARBO9G3l+4wFSCYtRBrwX1z+I+B61wQ=",
+        "lastModified": 1763154177,
+        "narHash": "sha256-LIIrMS2f2pPT2/BHs8dfGeupI23v5DNcoRz3W+iMsUA=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "88b8a563ff5704f4e8d8e5118fb911fa2110ca05",
+        "rev": "70be03ab23d0988224e152f5b52e2fbf44a6d8ee",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1763130179,
-        "narHash": "sha256-hcCj5AtMDirIDexA+9u5/r5Lzxkr7hXpxDokdZlTQUA=",
+        "lastModified": 1763367693,
+        "narHash": "sha256-qd/eX6u+h3rZQQWZmVshnxL4mVVSj2tkauqQXWvfov8=",
         "owner": "numtide",
         "repo": "nix-ai-tools",
-        "rev": "3de525217885be44da10f253a36c474d43f4933e",
+        "rev": "8fe6d9e9dee445e518c9d8c77d01761e6c199bd3",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762977756,
-        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
+        "lastModified": 1763283776,
+        "narHash": "sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c+i7novT85Uk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
+        "rev": "50a96edd8d0db6cc8db57dab6bb6d6ee1f3dc49a",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs-immich-kiosk": {
       "locked": {
-        "lastModified": 1763141337,
-        "narHash": "sha256-n4dvJYySvqRc2TLNpeCEZfMYDP1DH69nmbr3A28HKiM=",
+        "lastModified": 1763142697,
+        "narHash": "sha256-nRShyckh+Gydu8gzZNSQeqfpK7wLAGbq0XdXB7zZ7R4=",
         "owner": "tlvince",
         "repo": "nixpkgs",
-        "rev": "5044758f6766934f07dca612281f1e48b18521e5",
+        "rev": "c966c2e1a1da5e6a1c54581790d7ca717336afcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/827f2a23373a774a8805f84ca5344654c31f354b?narHash=sha256-RYHN8O/Aja59XDji6WSJZPkJpYVUfpSkyH%2BPEupBJqM%3D' (2025-11-12)
  → 'github:nix-community/home-manager/3670a78eee49deebe4825fc8ecc46b172d1a8391?narHash=sha256-yvdCYUL85zEDp2NzPUBmaNBXP6KnWEOhAk3j7PTfsKw%3D' (2025-11-16)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/88b8a563ff5704f4e8d8e5118fb911fa2110ca05?narHash=sha256-If6vQ%2BKvtKs3ARBO9G3l%2B4wFSCYtRBrwX1z%2BI%2BB61wQ%3D' (2025-11-03)
  → 'github:nix-community/lanzaboote/70be03ab23d0988224e152f5b52e2fbf44a6d8ee?narHash=sha256-LIIrMS2f2pPT2/BHs8dfGeupI23v5DNcoRz3W%2BiMsUA%3D' (2025-11-14)
• Updated input 'nix-ai-tools':
    'github:numtide/nix-ai-tools/3de525217885be44da10f253a36c474d43f4933e?narHash=sha256-hcCj5AtMDirIDexA%2B9u5/r5Lzxkr7hXpxDokdZlTQUA%3D' (2025-11-14)
  → 'github:numtide/nix-ai-tools/8fe6d9e9dee445e518c9d8c77d01761e6c199bd3?narHash=sha256-qd/eX6u%2Bh3rZQQWZmVshnxL4mVVSj2tkauqQXWvfov8%3D' (2025-11-17)
• Updated input 'nix-ai-tools/blueprint':
    'github:numtide/blueprint/633af1961cae8e02bc6195e6e599a6b09bf75217?narHash=sha256-wTQzbbQ6XHtvNJVuhJj%2BytZDRyNtwUKbrIfIvMvKNfQ%3D' (2025-10-28)
  → 'github:numtide/blueprint/5a9bba070f801d63e2af3c9ef00b86b212429f4f?narHash=sha256-O9Y%2BWer8wOh%2BN%2B4kcCK5p/VLrXyX%2Bktk0/s3HdZvJzk%3D' (2025-11-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c5ae371f1a6a7fd27823bc500d9390b38c05fa55?narHash=sha256-4PqRErxfe%2B2toFJFgcRKZ0UI9NSIOJa%2B7RXVtBhy4KE%3D' (2025-11-12)
  → 'github:nixos/nixpkgs/50a96edd8d0db6cc8db57dab6bb6d6ee1f3dc49a?narHash=sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c%2Bi7novT85Uk%3D' (2025-11-16)
• Updated input 'nixpkgs-immich-kiosk':
    'github:tlvince/nixpkgs/5044758f6766934f07dca612281f1e48b18521e5?narHash=sha256-n4dvJYySvqRc2TLNpeCEZfMYDP1DH69nmbr3A28HKiM%3D' (2025-11-14)
  → 'github:tlvince/nixpkgs/c966c2e1a1da5e6a1c54581790d7ca717336afcb?narHash=sha256-nRShyckh%2BGydu8gzZNSQeqfpK7wLAGbq0XdXB7zZ7R4%3D' (2025-11-14)
```