### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1754269165,
-        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
+        "lastModified": 1762538466,
+        "narHash": "sha256-8zrIPl6J+wLm9MH5ksHcW7BUHo7jSNOu0/hA0ohOOaM=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
+        "rev": "0cea393fffb39575c46b7a0318386467272182fe",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762276996,
-        "narHash": "sha256-TtcPgPmp2f0FAnc+DMEw4ardEgv1SGNR3/WFGH0N19M=",
+        "lastModified": 1763651264,
+        "narHash": "sha256-8vvwZbw0s7YvBMJeyPVpWke6lg6ROgtts5N2/SMCcv4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "af087d076d3860760b3323f6b583f4d828c1ac17",
+        "rev": "e86a89079587497174ccab6d0d142a65811a4fd9",
         "type": "github"
       },
       "original": {
@@ -118,32 +118,11 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "lanzaboote",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1754091436,
-        "narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
           "lanzaboote",
-          "pre-commit-hooks-nix",
+          "pre-commit",
           "nixpkgs"
         ]
       },
@@ -189,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763313531,
-        "narHash": "sha256-yvdCYUL85zEDp2NzPUBmaNBXP6KnWEOhAk3j7PTfsKw=",
+        "lastModified": 1763869804,
+        "narHash": "sha256-2lw+MnkrnygEyUl+3qZjnlCCJF/kJ57GUtYkAQPfLDA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3670a78eee49deebe4825fc8ecc46b172d1a8391",
+        "rev": "04c27d743d069cad58f9707ee8e165c471b1c7cd",
         "type": "github"
       },
       "original": {
@@ -205,20 +184,18 @@
     "lanzaboote": {
       "inputs": {
         "crane": "crane",
-        "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "pre-commit": "pre-commit",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1763154177,
-        "narHash": "sha256-LIIrMS2f2pPT2/BHs8dfGeupI23v5DNcoRz3W+iMsUA=",
+        "lastModified": 1763850934,
+        "narHash": "sha256-Dq2EktSlR+QZFnX9MfmJ1tjBMvsImufIbdkg6SjP+eo=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "70be03ab23d0988224e152f5b52e2fbf44a6d8ee",
+        "rev": "f16ac2d062746754047bba611a061e87f4ab6d60",
         "type": "github"
       },
       "original": {
@@ -236,11 +213,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1763367693,
-        "narHash": "sha256-qd/eX6u+h3rZQQWZmVshnxL4mVVSj2tkauqQXWvfov8=",
+        "lastModified": 1763888874,
+        "narHash": "sha256-FQWhAdRR9Q3rstvoomXROgszHj9fQ+LJ2Wk3Z/2/YbI=",
         "owner": "numtide",
         "repo": "nix-ai-tools",
-        "rev": "8fe6d9e9dee445e518c9d8c77d01761e6c199bd3",
+        "rev": "ff0e37ed721caf33365666ba652e7a1b10d47dc8",
         "type": "github"
       },
       "original": {
@@ -251,11 +228,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763283776,
-        "narHash": "sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c+i7novT85Uk=",
+        "lastModified": 1763678758,
+        "narHash": "sha256-+hBiJ+kG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "50a96edd8d0db6cc8db57dab6bb6d6ee1f3dc49a",
+        "rev": "117cc7f94e8072499b0a7aa4c52084fa4e11cc9b",
         "type": "github"
       },
       "original": {
@@ -297,12 +274,9 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks-nix": {
+    "pre-commit": {
       "inputs": {
-        "flake-compat": [
-          "lanzaboote",
-          "flake-compat"
-        ],
+        "flake-compat": "flake-compat",
         "gitignore": "gitignore",
         "nixpkgs": [
           "lanzaboote",
@@ -310,11 +284,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1763319842,
+        "narHash": "sha256-YG19IyrTdnVn0l3DvcUYm85u3PaqBt6tI6VvolcuHnA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "7275fa67fbbb75891c16d9dee7d88e58aea2d761",
         "type": "github"
       },
       "original": {
@@ -345,11 +319,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761791894,
-        "narHash": "sha256-myRIDh+PxaREz+z9LzbqBJF+SnTFJwkthKDX9zMyddY=",
+        "lastModified": 1763347184,
+        "narHash": "sha256-6QH8hpCYJxifvyHEYg+Da0BotUn03BwLIvYo3JAxuqQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "59c45eb69d9222a4362673141e00ff77842cd219",
+        "rev": "08895cce80433978d5bfd668efa41c5e24578cbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/af087d076d3860760b3323f6b583f4d828c1ac17?narHash=sha256-TtcPgPmp2f0FAnc%2BDMEw4ardEgv1SGNR3/WFGH0N19M%3D' (2025-11-04)
  → 'github:nix-community/disko/e86a89079587497174ccab6d0d142a65811a4fd9?narHash=sha256-8vvwZbw0s7YvBMJeyPVpWke6lg6ROgtts5N2/SMCcv4%3D' (2025-11-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/3670a78eee49deebe4825fc8ecc46b172d1a8391?narHash=sha256-yvdCYUL85zEDp2NzPUBmaNBXP6KnWEOhAk3j7PTfsKw%3D' (2025-11-16)
  → 'github:nix-community/home-manager/04c27d743d069cad58f9707ee8e165c471b1c7cd?narHash=sha256-2lw%2BMnkrnygEyUl%2B3qZjnlCCJF/kJ57GUtYkAQPfLDA%3D' (2025-11-23)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/70be03ab23d0988224e152f5b52e2fbf44a6d8ee?narHash=sha256-LIIrMS2f2pPT2/BHs8dfGeupI23v5DNcoRz3W%2BiMsUA%3D' (2025-11-14)
  → 'github:nix-community/lanzaboote/f16ac2d062746754047bba611a061e87f4ab6d60?narHash=sha256-Dq2EktSlR%2BQZFnX9MfmJ1tjBMvsImufIbdkg6SjP%2Beo%3D' (2025-11-22)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/444e81206df3f7d92780680e45858e31d2f07a08?narHash=sha256-0tcS8FHd4QjbCVoxN9jI%2BPjHgA4vc/IjkUSp%2BN3zy0U%3D' (2025-08-04)
  → 'github:ipetkov/crane/0cea393fffb39575c46b7a0318386467272182fe?narHash=sha256-8zrIPl6J%2BwLm9MH5ksHcW7BUHo7jSNOu0/hA0ohOOaM%3D' (2025-11-07)
• Removed input 'lanzaboote/flake-compat'
• Removed input 'lanzaboote/flake-parts'
• Removed input 'lanzaboote/flake-parts/nixpkgs-lib'
• Added input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/7275fa67fbbb75891c16d9dee7d88e58aea2d761?narHash=sha256-YG19IyrTdnVn0l3DvcUYm85u3PaqBt6tI6VvolcuHnA%3D' (2025-11-16)
• Added input 'lanzaboote/pre-commit/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Added input 'lanzaboote/pre-commit/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394?narHash=sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs%3D' (2024-02-28)
• Added input 'lanzaboote/pre-commit/gitignore/nixpkgs':
    follows 'lanzaboote/pre-commit/nixpkgs'
• Added input 'lanzaboote/pre-commit/nixpkgs':
    follows 'lanzaboote/nixpkgs'
• Removed input 'lanzaboote/pre-commit-hooks-nix'
• Removed input 'lanzaboote/pre-commit-hooks-nix/flake-compat'
• Removed input 'lanzaboote/pre-commit-hooks-nix/gitignore'
• Removed input 'lanzaboote/pre-commit-hooks-nix/gitignore/nixpkgs'
• Removed input 'lanzaboote/pre-commit-hooks-nix/nixpkgs'
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/59c45eb69d9222a4362673141e00ff77842cd219?narHash=sha256-myRIDh%2BPxaREz%2Bz9LzbqBJF%2BSnTFJwkthKDX9zMyddY%3D' (2025-10-30)
  → 'github:oxalica/rust-overlay/08895cce80433978d5bfd668efa41c5e24578cbd?narHash=sha256-6QH8hpCYJxifvyHEYg%2BDa0BotUn03BwLIvYo3JAxuqQ%3D' (2025-11-17)
• Updated input 'nix-ai-tools':
    'github:numtide/nix-ai-tools/8fe6d9e9dee445e518c9d8c77d01761e6c199bd3?narHash=sha256-qd/eX6u%2Bh3rZQQWZmVshnxL4mVVSj2tkauqQXWvfov8%3D' (2025-11-17)
  → 'github:numtide/nix-ai-tools/ff0e37ed721caf33365666ba652e7a1b10d47dc8?narHash=sha256-FQWhAdRR9Q3rstvoomXROgszHj9fQ%2BLJ2Wk3Z/2/YbI%3D' (2025-11-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/50a96edd8d0db6cc8db57dab6bb6d6ee1f3dc49a?narHash=sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c%2Bi7novT85Uk%3D' (2025-11-16)
  → 'github:nixos/nixpkgs/117cc7f94e8072499b0a7aa4c52084fa4e11cc9b?narHash=sha256-%2BhBiJ%2BkG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s%3D' (2025-11-20)
```