### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764350888,
-        "narHash": "sha256-6Rp18zavTlnlZzcoLoBTJMBahL2FycVkw2rAEs3cQvo=",
+        "lastModified": 1764627417,
+        "narHash": "sha256-D6xc3Rl8Ab6wucJWdvjNsGYGSxNjQHzRc2EZ6eeQ6l4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "2055a08fd0e2fd41318279a5355eb8a161accf26",
+        "rev": "5a88a6eceb8fd732b983e72b732f6f4b8269bef3",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764361670,
-        "narHash": "sha256-jgWzgpIaHbL3USIq0gihZeuy1lLf2YSfwvWEwnfAJUw=",
+        "lastModified": 1764788330,
+        "narHash": "sha256-hE/gXK+Z0j654T0tsW+KcndRqsgZXe8HyWchjBJgQpw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "780be8ef503a28939cf9dc7996b48ffb1a3e04c6",
+        "rev": "fca4cba863e76c26cfe48e5903c2ff4bac2b2d5d",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     },
     "jail-nix": {
       "locked": {
-        "lastModified": 1762804237,
-        "narHash": "sha256-YQO8yAzpoGJBm2gV/j7Dq2NtWoCbaRJHpKdaxcfcsDw=",
+        "lastModified": 1764535788,
+        "narHash": "sha256-QGjXRCmsMxSayEyail0wEpSiRCUaZaejCv2uKpcNH0E=",
         "owner": "~alexdavid",
         "repo": "jail.nix",
-        "rev": "98a6bd032c676b718c9fa26cc60a85eae92afd62",
+        "rev": "8f61c140858daf8ec21e6355b250cca6f5bf86fb",
         "type": "sourcehut"
       },
       "original": {
@@ -184,11 +184,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1763975256,
-        "narHash": "sha256-IhdDL+0YwlLz5Ty0EnAxWN/btemN9FxcQbYs/V/8jvs=",
+        "lastModified": 1764622702,
+        "narHash": "sha256-HggOVvg2U3EwT44wPHEwFKromf9qR9rTqfV1i3q7rYs=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "6803b15c4ab9df2dcc478254b4adb55524746ac7",
+        "rev": "6242b3b2b5e5afcf329027ed4eb5fa6e2eab10f1",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764242076,
-        "narHash": "sha256-sKoIWfnijJ0+9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI=",
+        "lastModified": 1764667669,
+        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fad6eac6077f03fe109c4d4eb171cf96791faa4",
+        "rev": "418468ac9527e799809c900eda37cbff999199b6",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
     },
     "nixpkgs-immich-kiosk": {
       "locked": {
-        "lastModified": 1764718246,
-        "narHash": "sha256-nEdMGCGRiuPY8Et6xJeN97s3BV2VFbYFo8uOVHm72VQ=",
+        "lastModified": 1764750910,
+        "narHash": "sha256-xhCVUyqLD5gZlE3LyDZUCveUnW/RIqP9yidHR606wXM=",
         "owner": "tlvince",
         "repo": "nixpkgs",
-        "rev": "ddea90594535d7e48cd3071d9c7cdfc945afb01c",
+        "rev": "a0f178530d937c85fdfbc0392be4ff3846351655",
         "type": "github"
       },
       "original": {
@@ -239,11 +239,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763741496,
-        "narHash": "sha256-uIRqs/H18YEtMOn1OkbnPH+aNTwXKx+iU3qnxEkVUd0=",
+        "lastModified": 1763988335,
+        "narHash": "sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh+M4Qc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "20e71a403c5de9ce5bd799031440da9728c1cda1",
+        "rev": "50b9238891e388c9fdc6a5c49e49c42533a1b5ce",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763865987,
-        "narHash": "sha256-DJpzM8Jz3B0azJcAoF+YFHr8rEbxYLJ0wy1kWZ29HOw=",
+        "lastModified": 1764470739,
+        "narHash": "sha256-sa9f81B1dWO16QtgDTWHX8DQbiHKzHndpaunY5EQtwE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "042d905c01a6eec3bcae8530dacb19cda9758a63",
+        "rev": "3bfa664055e1a09c6aedab5533c5fc8d6ca5741a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/2055a08fd0e2fd41318279a5355eb8a161accf26?narHash=sha256-6Rp18zavTlnlZzcoLoBTJMBahL2FycVkw2rAEs3cQvo%3D' (2025-11-28)
  → 'github:nix-community/disko/5a88a6eceb8fd732b983e72b732f6f4b8269bef3?narHash=sha256-D6xc3Rl8Ab6wucJWdvjNsGYGSxNjQHzRc2EZ6eeQ6l4%3D' (2025-12-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/780be8ef503a28939cf9dc7996b48ffb1a3e04c6?narHash=sha256-jgWzgpIaHbL3USIq0gihZeuy1lLf2YSfwvWEwnfAJUw%3D' (2025-11-28)
  → 'github:nix-community/home-manager/fca4cba863e76c26cfe48e5903c2ff4bac2b2d5d?narHash=sha256-hE/gXK%2BZ0j654T0tsW%2BKcndRqsgZXe8HyWchjBJgQpw%3D' (2025-12-03)
• Updated input 'jail-nix':
    'sourcehut:~alexdavid/jail.nix/98a6bd032c676b718c9fa26cc60a85eae92afd62?narHash=sha256-YQO8yAzpoGJBm2gV/j7Dq2NtWoCbaRJHpKdaxcfcsDw%3D' (2025-11-10)
  → 'sourcehut:~alexdavid/jail.nix/8f61c140858daf8ec21e6355b250cca6f5bf86fb?narHash=sha256-QGjXRCmsMxSayEyail0wEpSiRCUaZaejCv2uKpcNH0E%3D' (2025-11-30)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/6803b15c4ab9df2dcc478254b4adb55524746ac7?narHash=sha256-IhdDL%2B0YwlLz5Ty0EnAxWN/btemN9FxcQbYs/V/8jvs%3D' (2025-11-24)
  → 'github:nix-community/lanzaboote/6242b3b2b5e5afcf329027ed4eb5fa6e2eab10f1?narHash=sha256-HggOVvg2U3EwT44wPHEwFKromf9qR9rTqfV1i3q7rYs%3D' (2025-12-01)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/20e71a403c5de9ce5bd799031440da9728c1cda1?narHash=sha256-uIRqs/H18YEtMOn1OkbnPH%2BaNTwXKx%2BiU3qnxEkVUd0%3D' (2025-11-21)
  → 'github:cachix/pre-commit-hooks.nix/50b9238891e388c9fdc6a5c49e49c42533a1b5ce?narHash=sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh%2BM4Qc%3D' (2025-11-24)
• Updated input 'lanzaboote/pre-commit/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
  → 'github:edolstra/flake-compat/f387cd2afec9419c8ee37694406ca490c3f34ee5?narHash=sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4%3D' (2025-10-27)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/042d905c01a6eec3bcae8530dacb19cda9758a63?narHash=sha256-DJpzM8Jz3B0azJcAoF%2BYFHr8rEbxYLJ0wy1kWZ29HOw%3D' (2025-11-23)
  → 'github:oxalica/rust-overlay/3bfa664055e1a09c6aedab5533c5fc8d6ca5741a?narHash=sha256-sa9f81B1dWO16QtgDTWHX8DQbiHKzHndpaunY5EQtwE%3D' (2025-11-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/2fad6eac6077f03fe109c4d4eb171cf96791faa4?narHash=sha256-sKoIWfnijJ0%2B9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI%3D' (2025-11-27)
  → 'github:nixos/nixpkgs/418468ac9527e799809c900eda37cbff999199b6?narHash=sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y%3D' (2025-12-02)
• Updated input 'nixpkgs-immich-kiosk':
    'github:tlvince/nixpkgs/ddea90594535d7e48cd3071d9c7cdfc945afb01c?narHash=sha256-nEdMGCGRiuPY8Et6xJeN97s3BV2VFbYFo8uOVHm72VQ%3D' (2025-12-02)
  → 'github:tlvince/nixpkgs/a0f178530d937c85fdfbc0392be4ff3846351655?narHash=sha256-xhCVUyqLD5gZlE3LyDZUCveUnW/RIqP9yidHR606wXM%3D' (2025-12-03)
```