### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,22 +213,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-immich-kiosk": {
-      "locked": {
-        "lastModified": 1764750910,
-        "narHash": "sha256-xhCVUyqLD5gZlE3LyDZUCveUnW/RIqP9yidHR606wXM=",
-        "owner": "tlvince",
-        "repo": "nixpkgs",
-        "rev": "a0f178530d937c85fdfbc0392be4ff3846351655",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tlvince",
-        "ref": "kiosk-module",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "pre-commit": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -260,7 +244,6 @@
         "jail-nix": "jail-nix",
         "lanzaboote": "lanzaboote",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-immich-kiosk": "nixpkgs-immich-kiosk",
         "secrets": "secrets",
         "tmux-colours-onedark": "tmux-colours-onedark"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
     lanzaboote.inputs.nixpkgs.follows = "nixpkgs";
     lanzaboote.url = "github:nix-community/lanzaboote";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-immich-kiosk.url = "github:tlvince/nixpkgs/kiosk-module";
     secrets.flake = false;
     secrets.url = "github:tlvince/nixos-config-secrets";
     tmux-colours-onedark.flake = false;
@@ -26,7 +25,6 @@
     jail-nix,
     lanzaboote,
     nixpkgs,
-    nixpkgs-immich-kiosk,
     secrets,
     self,
     tmux-colours-onedark,
@@ -74,11 +72,6 @@
         };
 
         modules = [
-          # TODO: Upstream nixos/immich-kiosk module
-          # Issue URL: https://github.com/tlvince/nixos-config/issues/365
-          # https://nixpkgs-tracker.ocfox.me/?pr=461579
-          # labels: module:immich-kiosk, host:cm3588
-          "${nixpkgs-immich-kiosk}/nixos/modules/services/web-apps/immich-kiosk.nix"
           ./hosts/cm3588.nix
           agenix.nixosModules.default
           disko.nixosModules.disko


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/5a88a6eceb8fd732b983e72b732f6f4b8269bef3?narHash=sha256-D6xc3Rl8Ab6wucJWdvjNsGYGSxNjQHzRc2EZ6eeQ6l4%3D' (2025-12-01)
  → 'github:nix-community/disko/8e68aa819d6a9964c8ac45172e68b943b597c52a?narHash=sha256-qw9iaIIz8D%2BlwsTO28VOaZBAJG97jH4%2Bci2pe7ZJR6Q%3D' (2025-12-09)
• Updated input 'home-manager':
    'github:nix-community/home-manager/fca4cba863e76c26cfe48e5903c2ff4bac2b2d5d?narHash=sha256-hE/gXK%2BZ0j654T0tsW%2BKcndRqsgZXe8HyWchjBJgQpw%3D' (2025-12-03)
  → 'github:nix-community/home-manager/e5b1f87841810fc24772bf4389f9793702000c9b?narHash=sha256-BVVyAodLcAD8KOtR3yCStBHSE0WAH/xQWH9f0qsxbmk%3D' (2025-12-08)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/6242b3b2b5e5afcf329027ed4eb5fa6e2eab10f1?narHash=sha256-HggOVvg2U3EwT44wPHEwFKromf9qR9rTqfV1i3q7rYs%3D' (2025-12-01)
  → 'github:nix-community/lanzaboote/d125c8b4e696ae3642867c8cfa2c095ac631bea6?narHash=sha256-CI04kxXPY%2BFdPm8NgX2%2BTOgXhAu3hS7RQlhpI69ouVo%3D' (2025-12-09)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/d9e753122e51cee64eb8d2dddfe11148f339f5a2?narHash=sha256-j8iB0Yr4zAvQLueCZ5abxfk6fnG/SJ5JnGUziETjwfg%3D' (2025-11-23)
  → 'github:ipetkov/crane/69f538cdce5955fcd47abfed4395dc6d5194c1c5?narHash=sha256-aBVHGWWRzSpfL%2B%2BLubA0CwOOQ64WNLegrYHwsVuVN7A%3D' (2025-12-07)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/50b9238891e388c9fdc6a5c49e49c42533a1b5ce?narHash=sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh%2BM4Qc%3D' (2025-11-24)
  → 'github:cachix/pre-commit-hooks.nix/548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c?narHash=sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ%3D' (2025-12-06)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/3bfa664055e1a09c6aedab5533c5fc8d6ca5741a?narHash=sha256-sa9f81B1dWO16QtgDTWHX8DQbiHKzHndpaunY5EQtwE%3D' (2025-11-30)
  → 'github:oxalica/rust-overlay/769156779b41e8787a46ca3d7d76443aaf68be6f?narHash=sha256-KFDCdQcHJ0hE3Nt5Gm5enRIhmtEifAjpxgUQ3mzSJpA%3D' (2025-12-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/418468ac9527e799809c900eda37cbff999199b6?narHash=sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y%3D' (2025-12-02)
  → 'github:nixos/nixpkgs/addf7cf5f383a3101ecfba091b98d0a1263dc9b8?narHash=sha256-hM20uyap1a0M9d344I692r%2Bik4gTMyj60cQWO%2BhAYP8%3D' (2025-12-08)
```