### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765270797,
-        "narHash": "sha256-qw9iaIIz8D+lwsTO28VOaZBAJG97jH4+ci2pe7ZJR6Q=",
+        "lastModified": 1765326679,
+        "narHash": "sha256-fTLX9kDwLr9Y0rH/nG+h1XG5UU+jBcy0PFYn5eneRX8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8e68aa819d6a9964c8ac45172e68b943b597c52a",
+        "rev": "d64e5cdca35b5fad7c504f615357a7afe6d9c49e",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765217760,
-        "narHash": "sha256-BVVyAodLcAD8KOtR3yCStBHSE0WAH/xQWH9f0qsxbmk=",
+        "lastModified": 1765337252,
+        "narHash": "sha256-HuWQp8fM25fyWflbuunQkQI62Hg0ecJxWD52FAgmxqY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e5b1f87841810fc24772bf4389f9793702000c9b",
+        "rev": "13cc1efd78b943b98c08d74c9060a5b59bf86921",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1765275983,
-        "narHash": "sha256-CI04kxXPY+FdPm8NgX2+TOgXhAu3hS7RQlhpI69ouVo=",
+        "lastModified": 1765382359,
+        "narHash": "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "d125c8b4e696ae3642867c8cfa2c095ac631bea6",
+        "rev": "e8c096ade12ec9130ff931b0f0e25d2f1bc63607",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/8e68aa819d6a9964c8ac45172e68b943b597c52a?narHash=sha256-qw9iaIIz8D%2BlwsTO28VOaZBAJG97jH4%2Bci2pe7ZJR6Q%3D' (2025-12-09)
  → 'github:nix-community/disko/d64e5cdca35b5fad7c504f615357a7afe6d9c49e?narHash=sha256-fTLX9kDwLr9Y0rH/nG%2Bh1XG5UU%2BjBcy0PFYn5eneRX8%3D' (2025-12-10)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e5b1f87841810fc24772bf4389f9793702000c9b?narHash=sha256-BVVyAodLcAD8KOtR3yCStBHSE0WAH/xQWH9f0qsxbmk%3D' (2025-12-08)
  → 'github:nix-community/home-manager/13cc1efd78b943b98c08d74c9060a5b59bf86921?narHash=sha256-HuWQp8fM25fyWflbuunQkQI62Hg0ecJxWD52FAgmxqY%3D' (2025-12-10)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/d125c8b4e696ae3642867c8cfa2c095ac631bea6?narHash=sha256-CI04kxXPY%2BFdPm8NgX2%2BTOgXhAu3hS7RQlhpI69ouVo%3D' (2025-12-09)
  → 'github:nix-community/lanzaboote/e8c096ade12ec9130ff931b0f0e25d2f1bc63607?narHash=sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8%3D' (2025-12-10)
```