### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1765739568,
-        "narHash": "sha256-gQYx35Of4UDKUjAYvmxjUEh/DdszYeTtT6MDin4loGE=",
+        "lastModified": 1766194365,
+        "narHash": "sha256-4AFsUZ0kl6MXSm4BaQgItD0VGlEKR3iq7gIaL7TjBvc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "67d2baff0f9f677af35db61b32b5df6863bcc075",
+        "rev": "7d8ec2c71771937ab99790b45e6d9b93d15d9379",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766282146,
-        "narHash": "sha256-0V/nKU93KdYGi+5LB/MVo355obBJw/2z9b2xS3bPJxY=",
+        "lastModified": 1766881808,
+        "narHash": "sha256-JR7A2xS3EBPWFeONzhqez5vp7nKEsp7eLj2Ks210Srk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61fcc9de76b88e55578eb5d79fc80f2b236df707",
+        "rev": "d2e0458d6531885600b346e161c38790dc356fa8",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1766225539,
-        "narHash": "sha256-0Y6o3oUmQCxrzLIvZTcUAQCPEXAc+tU+N3ZjmzdrC28=",
+        "lastModified": 1766582277,
+        "narHash": "sha256-mUZRMKId7Uycwnt31RytPwhmY/8UTbk92ckZWHoS0Eg=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "14455220bef50f8df94f05e5763cdf51bc704acd",
+        "rev": "4c78502846c1ef668eedbd4f55d818ebac5388ac",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766070988,
-        "narHash": "sha256-G/WVghka6c4bAzMhTwT2vjLccg/awmHkdKSd2JrycLc=",
+        "lastModified": 1766651565,
+        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c6245e83d836d0433170a16eb185cefe0572f8b8",
+        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765464257,
-        "narHash": "sha256-dixPWKiHzh80PtD0aLuxYNQ0xP+843dfXG/yM3OzaYQ=",
+        "lastModified": 1765911976,
+        "narHash": "sha256-t3T/xm8zstHRLx+pIHxVpQTiySbKqcQbK+r+01XVKc0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "09e45f2598e1a8499c3594fe11ec2943f34fe509",
+        "rev": "b68b780b69702a090c8bb1b973bab13756cc7a27",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765680428,
-        "narHash": "sha256-fyPmRof9SZeI14ChPk5rVPOm7ISiiGkwGCunkhM+eUg=",
+        "lastModified": 1766285238,
+        "narHash": "sha256-DqVXFZ4ToiFHgnxebMWVL70W+U+JOxpmfD37eWD/Qc8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "eb3898d8ef143d4bf0f7f2229105fc51c7731b2f",
+        "rev": "c4249d0c370d573d95e33b472014eae4f2507c2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/61fcc9de76b88e55578eb5d79fc80f2b236df707?narHash=sha256-0V/nKU93KdYGi%2B5LB/MVo355obBJw/2z9b2xS3bPJxY%3D' (2025-12-21)
  → 'github:nix-community/home-manager/d2e0458d6531885600b346e161c38790dc356fa8?narHash=sha256-JR7A2xS3EBPWFeONzhqez5vp7nKEsp7eLj2Ks210Srk%3D' (2025-12-28)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/14455220bef50f8df94f05e5763cdf51bc704acd?narHash=sha256-0Y6o3oUmQCxrzLIvZTcUAQCPEXAc%2BtU%2BN3ZjmzdrC28%3D' (2025-12-20)
  → 'github:nix-community/lanzaboote/4c78502846c1ef668eedbd4f55d818ebac5388ac?narHash=sha256-mUZRMKId7Uycwnt31RytPwhmY/8UTbk92ckZWHoS0Eg%3D' (2025-12-24)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/67d2baff0f9f677af35db61b32b5df6863bcc075?narHash=sha256-gQYx35Of4UDKUjAYvmxjUEh/DdszYeTtT6MDin4loGE%3D' (2025-12-14)
  → 'github:ipetkov/crane/7d8ec2c71771937ab99790b45e6d9b93d15d9379?narHash=sha256-4AFsUZ0kl6MXSm4BaQgItD0VGlEKR3iq7gIaL7TjBvc%3D' (2025-12-20)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/09e45f2598e1a8499c3594fe11ec2943f34fe509?narHash=sha256-dixPWKiHzh80PtD0aLuxYNQ0xP%2B843dfXG/yM3OzaYQ%3D' (2025-12-11)
  → 'github:cachix/pre-commit-hooks.nix/b68b780b69702a090c8bb1b973bab13756cc7a27?narHash=sha256-t3T/xm8zstHRLx%2BpIHxVpQTiySbKqcQbK%2Br%2B01XVKc0%3D' (2025-12-16)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/eb3898d8ef143d4bf0f7f2229105fc51c7731b2f?narHash=sha256-fyPmRof9SZeI14ChPk5rVPOm7ISiiGkwGCunkhM%2BeUg%3D' (2025-12-14)
  → 'github:oxalica/rust-overlay/c4249d0c370d573d95e33b472014eae4f2507c2f?narHash=sha256-DqVXFZ4ToiFHgnxebMWVL70W%2BU%2BJOxpmfD37eWD/Qc8%3D' (2025-12-21)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c6245e83d836d0433170a16eb185cefe0572f8b8?narHash=sha256-G/WVghka6c4bAzMhTwT2vjLccg/awmHkdKSd2JrycLc%3D' (2025-12-18)
  → 'github:nixos/nixpkgs/3e2499d5539c16d0d173ba53552a4ff8547f4539?narHash=sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU%3D' (2025-12-25)
```