### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1767461147,
-        "narHash": "sha256-TH/xTeq/RI+DOzo+c+4F431eVuBpYVwQwBxzURe7kcI=",
+        "lastModified": 1767744144,
+        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7d59256814085fd9666a2ae3e774dc5ee216b630",
+        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767718503,
-        "narHash": "sha256-V+VkFs0aSG0ca8p/N3gib7FAf4cq9jyr5Gm+ZBrHQpo=",
+        "lastModified": 1768220509,
+        "narHash": "sha256-8wMrJP/Xk5Dkm0TxzaERLt3eGFEhHTWaJKUpK3AoL4o=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "9f48ffaca1f44b3e590976b4da8666a9e86e6eb1",
+        "rev": "7b1d394e7d9112d4060e12ef3271b38a7c43e83b",
         "type": "github"
       },
       "original": {
@@ -218,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768068402,
-        "narHash": "sha256-bAXnnJZKJiF7Xr6eNW6+PhBf1lg2P1aFUO9+xgWkXfA=",
+        "lastModified": 1768434960,
+        "narHash": "sha256-cJbFn17oyg6qAraLr+NVeNJrXsrzJdrudkzI4H2iTcg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8bc5473b6bc2b6e1529a9c4040411e1199c43b4c",
+        "rev": "b4d88c9ac42ae1a745283f6547701da43b6e9f9b",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1767697030,
-        "narHash": "sha256-0iVZ99H3kR5h6Lhw8kDDuUc5C/k6iismeWgCS1qWTQ4=",
+        "lastModified": 1768307256,
+        "narHash": "sha256-3yDvlAqWa0Vk3B9hFRJJrSs1xc+FwVQFLtu//VrTR4c=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "657469e8f036334db768daaf7732b1174676054b",
+        "rev": "7e031eb535a494582f4fc58735b5aecba7b57058",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768127708,
-        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "lastModified": 1768305791,
+        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1768135144,
-        "narHash": "sha256-c9q5pGqfVEcxqXLmjug0skKdE4IT4zFKbQdEzXGHTVY=",
+        "lastModified": 1768447714,
+        "narHash": "sha256-DtjEJdyMDzS5IYmo+XxnKjPJ56Dh+WGysnRcsYjeLeQ=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "c7fe3c1818d01f71f2e1a0ec9b8e1c6a7e5c171b",
+        "rev": "efad7858830bf2670ab4bcff3a6d56e3fdddc97d",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767495280,
-        "narHash": "sha256-hEEgtE/RSRigw8xscchGymf/t1nluZwTfru4QF6O1CQ=",
+        "lastModified": 1768272338,
+        "narHash": "sha256-Tg/kL8eKMpZtceDvBDQYU8zowgpr7ucFRnpP/AtfuRM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cb24c5cc207ba8e9a4ce245eedd2d37c3a988bc1",
+        "rev": "03dda130a8701b08b0347fcaf850a190c53a3c1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/9f48ffaca1f44b3e590976b4da8666a9e86e6eb1?narHash=sha256-V%2BVkFs0aSG0ca8p/N3gib7FAf4cq9jyr5Gm%2BZBrHQpo%3D' (2026-01-06)
  → 'github:nix-darwin/nix-darwin/7b1d394e7d9112d4060e12ef3271b38a7c43e83b?narHash=sha256-8wMrJP/Xk5Dkm0TxzaERLt3eGFEhHTWaJKUpK3AoL4o%3D' (2026-01-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8bc5473b6bc2b6e1529a9c4040411e1199c43b4c?narHash=sha256-bAXnnJZKJiF7Xr6eNW6%2BPhBf1lg2P1aFUO9%2BxgWkXfA%3D' (2026-01-10)
  → 'github:nix-community/home-manager/b4d88c9ac42ae1a745283f6547701da43b6e9f9b?narHash=sha256-cJbFn17oyg6qAraLr%2BNVeNJrXsrzJdrudkzI4H2iTcg%3D' (2026-01-14)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/657469e8f036334db768daaf7732b1174676054b?narHash=sha256-0iVZ99H3kR5h6Lhw8kDDuUc5C/k6iismeWgCS1qWTQ4%3D' (2026-01-06)
  → 'github:nix-community/lanzaboote/7e031eb535a494582f4fc58735b5aecba7b57058?narHash=sha256-3yDvlAqWa0Vk3B9hFRJJrSs1xc%2BFwVQFLtu//VrTR4c%3D' (2026-01-13)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/7d59256814085fd9666a2ae3e774dc5ee216b630?narHash=sha256-TH/xTeq/RI%2BDOzo%2Bc%2B4F431eVuBpYVwQwBxzURe7kcI%3D' (2026-01-03)
  → 'github:ipetkov/crane/2fb033290bf6b23f226d4c8b32f7f7a16b043d7e?narHash=sha256-9/9ntI0D%2BHbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q%3D' (2026-01-07)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/cb24c5cc207ba8e9a4ce245eedd2d37c3a988bc1?narHash=sha256-hEEgtE/RSRigw8xscchGymf/t1nluZwTfru4QF6O1CQ%3D' (2026-01-04)
  → 'github:oxalica/rust-overlay/03dda130a8701b08b0347fcaf850a190c53a3c1e?narHash=sha256-Tg/kL8eKMpZtceDvBDQYU8zowgpr7ucFRnpP/AtfuRM%3D' (2026-01-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38?narHash=sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs%3D' (2026-01-11)
  → 'github:nixos/nixpkgs/1412caf7bf9e660f2f962917c14b1ea1c3bc695e?narHash=sha256-AIdl6WAn9aymeaH/NvBj0H9qM%2BXuAuYbGMZaP0zcXAQ%3D' (2026-01-13)
• Updated input 'nvf':
    'github:notashelf/nvf/c7fe3c1818d01f71f2e1a0ec9b8e1c6a7e5c171b?narHash=sha256-c9q5pGqfVEcxqXLmjug0skKdE4IT4zFKbQdEzXGHTVY%3D' (2026-01-11)
  → 'github:notashelf/nvf/efad7858830bf2670ab4bcff3a6d56e3fdddc97d?narHash=sha256-DtjEJdyMDzS5IYmo%2BXxnKjPJ56Dh%2BWGysnRcsYjeLeQ%3D' (2026-01-15)
```