### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -218,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769579508,
-        "narHash": "sha256-EE2bs7xFrC64qrj0N2zP6E6e/nmhcdw6v/grdYi+BiY=",
+        "lastModified": 1769978395,
+        "narHash": "sha256-gj1yP3spUb1vGtaF5qPhshd2j0cg4xf51pklDsIm19Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eec72f127831326b042d1f35003767a4ab6a9516",
+        "rev": "984708c34d3495a518e6ab6b8633469bbca2f77a",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1769417433,
-        "narHash": "sha256-0WZ7I/N9InaBHL96/qdiJxg8mqFW3vRla8Z062JmQFE=",
+        "lastModified": 1769949118,
+        "narHash": "sha256-Ue9kYZenqMw9yHGFnBpoWxQqhs2tlH/el4AxKVicXBE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "1902463415745b992dbaf301b2a35a1277be1584",
+        "rev": "0be0641613a13323a61a6406c46b6f28b8894395",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
     },
     "mnw": {
       "locked": {
-        "lastModified": 1768701608,
-        "narHash": "sha256-kSvWF3Xt2HW9hmV5V7i8PqeWJIBUKmuKoHhOgj3Znzs=",
+        "lastModified": 1769981889,
+        "narHash": "sha256-ndI7AxL/6auelkLHngdUGVImBiHkG8w2N2fOTKZKn4k=",
         "owner": "Gerg-L",
         "repo": "mnw",
-        "rev": "20d63a8a1ae400557c770052a46a9840e768926b",
+        "rev": "332fed8f43b77149c582f1782683d6aeee1f07cf",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769461804,
-        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "lastModified": 1769789167,
+        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1769555186,
-        "narHash": "sha256-wNoPRTt5ZAzXnu3uoan4p8h1hC0EvEurAX2708p1umU=",
+        "lastModified": 1769983625,
+        "narHash": "sha256-tdOA/dHP/MvAfufR6ZFmW1RVK0ABZBmUyGg8X9+6rLs=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "dacc7270a5a6db3dd2bdc5ae1713f1fe975ecbd8",
+        "rev": "7ec261937585390e5da53d689ec66a30d11e0f8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/eec72f127831326b042d1f35003767a4ab6a9516?narHash=sha256-EE2bs7xFrC64qrj0N2zP6E6e/nmhcdw6v/grdYi%2BBiY%3D' (2026-01-28)
  → 'github:nix-community/home-manager/984708c34d3495a518e6ab6b8633469bbca2f77a?narHash=sha256-gj1yP3spUb1vGtaF5qPhshd2j0cg4xf51pklDsIm19Q%3D' (2026-02-01)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/1902463415745b992dbaf301b2a35a1277be1584?narHash=sha256-0WZ7I/N9InaBHL96/qdiJxg8mqFW3vRla8Z062JmQFE%3D' (2026-01-26)
  → 'github:nix-community/lanzaboote/0be0641613a13323a61a6406c46b6f28b8894395?narHash=sha256-Ue9kYZenqMw9yHGFnBpoWxQqhs2tlH/el4AxKVicXBE%3D' (2026-02-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bfc1b8a4574108ceef22f02bafcf6611380c100d?narHash=sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI%3D' (2026-01-26)
  → 'github:nixos/nixpkgs/62c8382960464ceb98ea593cb8321a2cf8f9e3e5?narHash=sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8%3D' (2026-01-30)
• Updated input 'nvf':
    'github:notashelf/nvf/dacc7270a5a6db3dd2bdc5ae1713f1fe975ecbd8?narHash=sha256-wNoPRTt5ZAzXnu3uoan4p8h1hC0EvEurAX2708p1umU%3D' (2026-01-27)
  → 'github:notashelf/nvf/7ec261937585390e5da53d689ec66a30d11e0f8c?narHash=sha256-tdOA/dHP/MvAfufR6ZFmW1RVK0ABZBmUyGg8X9%2B6rLs%3D' (2026-02-01)
• Updated input 'nvf/mnw':
    'github:Gerg-L/mnw/20d63a8a1ae400557c770052a46a9840e768926b?narHash=sha256-kSvWF3Xt2HW9hmV5V7i8PqeWJIBUKmuKoHhOgj3Znzs%3D' (2026-01-18)
  → 'github:Gerg-L/mnw/332fed8f43b77149c582f1782683d6aeee1f07cf?narHash=sha256-ndI7AxL/6auelkLHngdUGVImBiHkG8w2N2fOTKZKn4k%3D' (2026-02-01)
```