### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1762618334,
-        "narHash": "sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L+VSybPfiIgzU8lbQ=",
+        "lastModified": 1770165109,
+        "narHash": "sha256-9VnK6Oqai65puVJ4WYtCTvlJeXxMzAp/69HhQuTdl/I=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "fcdea223397448d35d9b31f798479227e80183f6",
+        "rev": "b027ee29d959fda4b60b57566d64c98a202e0feb",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1769287525,
-        "narHash": "sha256-gABuYA6BzoRMLuPaeO5p7SLrpd4qExgkwEmYaYQY4bM=",
+        "lastModified": 1769737823,
+        "narHash": "sha256-DrBaNpZ+sJ4stXm+0nBX7zqZT9t9P22zbk6m5YhQxS4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0314e365877a85c9e5758f9ea77a9972afbb4c21",
+        "rev": "b2f45c3830aa96b7456a4c4bc327d04d7a43e1ba",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768764703,
-        "narHash": "sha256-5ulSDyOG1U+1sJhkJHYsUOWEsmtLl97O0NTVMvgIVyc=",
+        "lastModified": 1770184146,
+        "narHash": "sha256-DsqnN6LvXmohTRaal7tVZO/AKBuZ02kPBiZKSU4qa/k=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "0fc4e7ac670a0ed874abacf73c4b072a6a58064b",
+        "rev": "0d7874ef7e3ba02d58bebb871e6e29da36fa1b37",
         "type": "github"
       },
       "original": {
@@ -218,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769978395,
-        "narHash": "sha256-gj1yP3spUb1vGtaF5qPhshd2j0cg4xf51pklDsIm19Q=",
+        "lastModified": 1770586272,
+        "narHash": "sha256-Ucci8mu8QfxwzyfER2DQDbvW9t1BnTUJhBmY7ybralo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "984708c34d3495a518e6ab6b8633469bbca2f77a",
+        "rev": "b1f916ba052341edc1f80d4b2399f1092a4873ca",
         "type": "github"
       },
       "original": {
@@ -233,11 +233,11 @@
     },
     "jail-nix": {
       "locked": {
-        "lastModified": 1765903853,
-        "narHash": "sha256-buoPpx7moJzAXbLuHAImn6x9fGRdk3x0T57goPv1vnc=",
+        "lastModified": 1770418571,
+        "narHash": "sha256-EzQUbe1gwW/xpJoMuMeblWcjAEF+F92cz/enz0Mz/qo=",
         "owner": "~alexdavid",
         "repo": "jail.nix",
-        "rev": "bf9f49c8118e7a77b68a675dbe26e93e91412066",
+        "rev": "c141cf8cc68617625b4a28a7d8ce0a35904815d5",
         "type": "sourcehut"
       },
       "original": {
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1769949118,
-        "narHash": "sha256-Ue9kYZenqMw9yHGFnBpoWxQqhs2tlH/el4AxKVicXBE=",
+        "lastModified": 1770579389,
+        "narHash": "sha256-2OwcZVHHsq3DSnJsUOiw0i/ovRqdlIG4uj5RPRql+8I=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0be0641613a13323a61a6406c46b6f28b8894395",
+        "rev": "7b637233a79e6041affba3f33957995c57f4b140",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769789167,
-        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "lastModified": 1770562336,
+        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1769983625,
-        "narHash": "sha256-tdOA/dHP/MvAfufR6ZFmW1RVK0ABZBmUyGg8X9+6rLs=",
+        "lastModified": 1770572967,
+        "narHash": "sha256-uQ4g+gypEXoNE6bgQq1UP3mrwUNuemhdD3A7G9tbchk=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "7ec261937585390e5da53d689ec66a30d11e0f8c",
+        "rev": "7a2c7c23966122eac80620dd503bf2b1163ed6d4",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769069492,
-        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "lastModified": 1769939035,
+        "narHash": "sha256-Fok2AmefgVA0+eprw2NDwqKkPGEI5wvR+twiZagBvrg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
         "type": "github"
       },
       "original": {
@@ -393,11 +393,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769309768,
-        "narHash": "sha256-AbOIlNO+JoqRJkK1VrnDXhxuX6CrdtIu2hSuy4pxi3g=",
+        "lastModified": 1770001842,
+        "narHash": "sha256-ZAyTeILfdWwDp1nuF0RK3McBduMi49qnJvrS+3Ezpac=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "140c9dc582cb73ada2d63a2180524fcaa744fad5",
+        "rev": "5018343419ea808f8a413241381976b7e60951f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'agenix':
    'github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6?narHash=sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L%2BVSybPfiIgzU8lbQ%3D' (2025-11-08)
  → 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb?narHash=sha256-9VnK6Oqai65puVJ4WYtCTvlJeXxMzAp/69HhQuTdl/I%3D' (2026-02-04)
• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/0fc4e7ac670a0ed874abacf73c4b072a6a58064b?narHash=sha256-5ulSDyOG1U%2B1sJhkJHYsUOWEsmtLl97O0NTVMvgIVyc%3D' (2026-01-18)
  → 'github:nix-darwin/nix-darwin/0d7874ef7e3ba02d58bebb871e6e29da36fa1b37?narHash=sha256-DsqnN6LvXmohTRaal7tVZO/AKBuZ02kPBiZKSU4qa/k%3D' (2026-02-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/984708c34d3495a518e6ab6b8633469bbca2f77a?narHash=sha256-gj1yP3spUb1vGtaF5qPhshd2j0cg4xf51pklDsIm19Q%3D' (2026-02-01)
  → 'github:nix-community/home-manager/b1f916ba052341edc1f80d4b2399f1092a4873ca?narHash=sha256-Ucci8mu8QfxwzyfER2DQDbvW9t1BnTUJhBmY7ybralo%3D' (2026-02-08)
• Updated input 'jail-nix':
    'sourcehut:~alexdavid/jail.nix/bf9f49c8118e7a77b68a675dbe26e93e91412066?narHash=sha256-buoPpx7moJzAXbLuHAImn6x9fGRdk3x0T57goPv1vnc%3D' (2025-12-16)
  → 'sourcehut:~alexdavid/jail.nix/c141cf8cc68617625b4a28a7d8ce0a35904815d5?narHash=sha256-EzQUbe1gwW/xpJoMuMeblWcjAEF%2BF92cz/enz0Mz/qo%3D' (2026-02-06)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/0be0641613a13323a61a6406c46b6f28b8894395?narHash=sha256-Ue9kYZenqMw9yHGFnBpoWxQqhs2tlH/el4AxKVicXBE%3D' (2026-02-01)
  → 'github:nix-community/lanzaboote/7b637233a79e6041affba3f33957995c57f4b140?narHash=sha256-2OwcZVHHsq3DSnJsUOiw0i/ovRqdlIG4uj5RPRql%2B8I%3D' (2026-02-08)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/0314e365877a85c9e5758f9ea77a9972afbb4c21?narHash=sha256-gABuYA6BzoRMLuPaeO5p7SLrpd4qExgkwEmYaYQY4bM%3D' (2026-01-24)
  → 'github:ipetkov/crane/b2f45c3830aa96b7456a4c4bc327d04d7a43e1ba?narHash=sha256-DrBaNpZ%2BsJ4stXm%2B0nBX7zqZT9t9P22zbk6m5YhQxS4%3D' (2026-01-30)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/a1ef738813b15cf8ec759bdff5761b027e3e1d23?narHash=sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W%2Bxc49RL/U%3D' (2026-01-22)
  → 'github:cachix/pre-commit-hooks.nix/a8ca480175326551d6c4121498316261cbb5b260?narHash=sha256-Fok2AmefgVA0%2Beprw2NDwqKkPGEI5wvR%2BtwiZagBvrg%3D' (2026-02-01)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/140c9dc582cb73ada2d63a2180524fcaa744fad5?narHash=sha256-AbOIlNO%2BJoqRJkK1VrnDXhxuX6CrdtIu2hSuy4pxi3g%3D' (2026-01-25)
  → 'github:oxalica/rust-overlay/5018343419ea808f8a413241381976b7e60951f2?narHash=sha256-ZAyTeILfdWwDp1nuF0RK3McBduMi49qnJvrS%2B3Ezpac%3D' (2026-02-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/62c8382960464ceb98ea593cb8321a2cf8f9e3e5?narHash=sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8%3D' (2026-01-30)
  → 'github:nixos/nixpkgs/d6c71932130818840fc8fe9509cf50be8c64634f?narHash=sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84%3D' (2026-02-08)
• Updated input 'nvf':
    'github:notashelf/nvf/7ec261937585390e5da53d689ec66a30d11e0f8c?narHash=sha256-tdOA/dHP/MvAfufR6ZFmW1RVK0ABZBmUyGg8X9%2B6rLs%3D' (2026-02-01)
  → 'github:notashelf/nvf/7a2c7c23966122eac80620dd503bf2b1163ed6d4?narHash=sha256-uQ4g%2BgypEXoNE6bgQq1UP3mrwUNuemhdD3A7G9tbchk%3D' (2026-02-08)
```