### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1770419512,
-        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
+        "lastModified": 1771121070,
+        "narHash": "sha256-aIlv7FRXF9q70DNJPI237dEDAznSKaXmL5lfK/Id/bI=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
+        "rev": "a2812c19f1ed2e5ed5ce2ef7109798b575c180e1",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770922915,
-        "narHash": "sha256-6J/JoK9iL7sHvKJcGW2KId2agaKv1OGypsa7kN+ZBD4=",
+        "lastModified": 1771520882,
+        "narHash": "sha256-9SeTZ4Pwr730YfT7V8Azb8GFbwk1ZwiQDAwft3qAD+o=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "6c5a56295d2a24e43bcd8af838def1b9a95746b2",
+        "rev": "6a7fdcd5839ec8b135821179eea3b58092171bcf",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769524058,
-        "narHash": "sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE=",
+        "lastModified": 1771469470,
+        "narHash": "sha256-GnqdqhrguKNN3HtVfl6z+zbV9R9jhHFm3Z8nu7R6ml0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "71a3fc97d80881e91710fe721f1158d3b96ae14d",
+        "rev": "4707eec8d1d2db5182ea06ed48c820a86a42dc13",
         "type": "github"
       },
       "original": {
@@ -218,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771188132,
-        "narHash": "sha256-qLXxN/tPrZtnekaLBQuVtxQfvqqs5cT5WbyH4zZaTGI=",
+        "lastModified": 1771756436,
+        "narHash": "sha256-Tl2I0YXdhSTufGqAaD1ySh8x+cvVsEI1mJyJg12lxhI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ae8003d8b61d0d373e7ca3da1a48f9c870d15df9",
+        "rev": "5bd3589390b431a63072868a90c0f24771ff4cbb",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1770734117,
-        "narHash": "sha256-PNXSnK507MRj+hYMgnUR7InNJzVCmOfsjHV4YXZgpwQ=",
+        "lastModified": 1771834715,
+        "narHash": "sha256-5VI2KiMifx3Dca7nDJzctO3HpnS6zrvesdkLoZBrQRY=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "2038a9a19adb886eccba775321b055fdbdc5029d",
+        "rev": "b798c53da0f7e521317a5413335096a21070cf0b",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1771148535,
-        "narHash": "sha256-UmpHVCVgqIpWWahmEcFb1pOwyI3PGKpgrL2BiRGDWec=",
+        "lastModified": 1771704400,
+        "narHash": "sha256-8U9xnN4HdxPfAXAft3lBsArWSv1ZTTxJci1lOA/xpno=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "d6338d4c4cee45634dd54dfb9cbb6abc5a86752e",
+        "rev": "5c38b357da7e8c870350cd1847fb5b2602a28eb0",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769939035,
-        "narHash": "sha256-Fok2AmefgVA0+eprw2NDwqKkPGEI5wvR+twiZagBvrg=",
+        "lastModified": 1770726378,
+        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
+        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
         "type": "github"
       },
       "original": {
@@ -393,11 +393,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770520253,
-        "narHash": "sha256-6rWuHgSENXKnC6HGGAdRolQrnp/8IzscDn7FQEo1uEQ=",
+        "lastModified": 1771125043,
+        "narHash": "sha256-ldf/s49n6rOAxl7pYLJGGS1N/assoHkCOWdEdLyNZkc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ebb8a141f60bb0ec33836333e0ca7928a072217f",
+        "rev": "4912f951a26dc8142b176be2c2ad834319dc06e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/6c5a56295d2a24e43bcd8af838def1b9a95746b2?narHash=sha256-6J/JoK9iL7sHvKJcGW2KId2agaKv1OGypsa7kN%2BZBD4%3D' (2026-02-12)
  → 'github:nix-darwin/nix-darwin/6a7fdcd5839ec8b135821179eea3b58092171bcf?narHash=sha256-9SeTZ4Pwr730YfT7V8Azb8GFbwk1ZwiQDAwft3qAD%2Bo%3D' (2026-02-19)
• Updated input 'disko':
    'github:nix-community/disko/71a3fc97d80881e91710fe721f1158d3b96ae14d?narHash=sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE%3D' (2026-01-27)
  → 'github:nix-community/disko/4707eec8d1d2db5182ea06ed48c820a86a42dc13?narHash=sha256-GnqdqhrguKNN3HtVfl6z%2BzbV9R9jhHFm3Z8nu7R6ml0%3D' (2026-02-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ae8003d8b61d0d373e7ca3da1a48f9c870d15df9?narHash=sha256-qLXxN/tPrZtnekaLBQuVtxQfvqqs5cT5WbyH4zZaTGI%3D' (2026-02-15)
  → 'github:nix-community/home-manager/5bd3589390b431a63072868a90c0f24771ff4cbb?narHash=sha256-Tl2I0YXdhSTufGqAaD1ySh8x%2BcvVsEI1mJyJg12lxhI%3D' (2026-02-22)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/2038a9a19adb886eccba775321b055fdbdc5029d?narHash=sha256-PNXSnK507MRj%2BhYMgnUR7InNJzVCmOfsjHV4YXZgpwQ%3D' (2026-02-10)
  → 'github:nix-community/lanzaboote/b798c53da0f7e521317a5413335096a21070cf0b?narHash=sha256-5VI2KiMifx3Dca7nDJzctO3HpnS6zrvesdkLoZBrQRY%3D' (2026-02-23)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/2510f2cbc3ccd237f700bb213756a8f35c32d8d7?narHash=sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo%3D' (2026-02-06)
  → 'github:ipetkov/crane/a2812c19f1ed2e5ed5ce2ef7109798b575c180e1?narHash=sha256-aIlv7FRXF9q70DNJPI237dEDAznSKaXmL5lfK/Id/bI%3D' (2026-02-15)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/a8ca480175326551d6c4121498316261cbb5b260?narHash=sha256-Fok2AmefgVA0%2Beprw2NDwqKkPGEI5wvR%2BtwiZagBvrg%3D' (2026-02-01)
  → 'github:cachix/pre-commit-hooks.nix/5eaaedde414f6eb1aea8b8525c466dc37bba95ae?narHash=sha256-kck%2BvIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8%3D' (2026-02-10)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/ebb8a141f60bb0ec33836333e0ca7928a072217f?narHash=sha256-6rWuHgSENXKnC6HGGAdRolQrnp/8IzscDn7FQEo1uEQ%3D' (2026-02-08)
  → 'github:oxalica/rust-overlay/4912f951a26dc8142b176be2c2ad834319dc06e8?narHash=sha256-ldf/s49n6rOAxl7pYLJGGS1N/assoHkCOWdEdLyNZkc%3D' (2026-02-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a82ccc39b39b621151d6732718e3e250109076fa?narHash=sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb%2BZnAo5RzSxJg%3D' (2026-02-13)
  → 'github:nixos/nixpkgs/0182a361324364ae3f436a63005877674cf45efb?narHash=sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ%3D' (2026-02-17)
• Updated input 'nvf':
    'github:notashelf/nvf/d6338d4c4cee45634dd54dfb9cbb6abc5a86752e?narHash=sha256-UmpHVCVgqIpWWahmEcFb1pOwyI3PGKpgrL2BiRGDWec%3D' (2026-02-15)
  → 'github:notashelf/nvf/5c38b357da7e8c870350cd1847fb5b2602a28eb0?narHash=sha256-8U9xnN4HdxPfAXAft3lBsArWSv1ZTTxJci1lOA/xpno%3D' (2026-02-21)
```