### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1771121070,
-        "narHash": "sha256-aIlv7FRXF9q70DNJPI237dEDAznSKaXmL5lfK/Id/bI=",
+        "lastModified": 1771796463,
+        "narHash": "sha256-9bCDuUzpwJXcHMQYMS1yNuzYMmKO/CCwCexpjWOl62I=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a2812c19f1ed2e5ed5ce2ef7109798b575c180e1",
+        "rev": "3d3de3313e263e04894f284ac18177bd26169bad",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771520882,
-        "narHash": "sha256-9SeTZ4Pwr730YfT7V8Azb8GFbwk1ZwiQDAwft3qAD+o=",
+        "lastModified": 1772379624,
+        "narHash": "sha256-NG9LLTWlz4YiaTAiRGChbrzbVxBfX+Auq4Ab/SWmk4A=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "6a7fdcd5839ec8b135821179eea3b58092171bcf",
+        "rev": "52d061516108769656a8bd9c6e811c677ec5b462",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771469470,
-        "narHash": "sha256-GnqdqhrguKNN3HtVfl6z+zbV9R9jhHFm3Z8nu7R6ml0=",
+        "lastModified": 1772420042,
+        "narHash": "sha256-naZz40TUFMa0E0CutvwWsSPhgD5JldyTUDEgP9ADpfU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4707eec8d1d2db5182ea06ed48c820a86a42dc13",
+        "rev": "5af7af10f14706e4095bd6bc0d9373eb097283c6",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771756436,
-        "narHash": "sha256-Tl2I0YXdhSTufGqAaD1ySh8x+cvVsEI1mJyJg12lxhI=",
+        "lastModified": 1772516620,
+        "narHash": "sha256-2r4cKdqCVlQkvcTcLUMxmsmAYZZxCMd//w/PnDnukTE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5bd3589390b431a63072868a90c0f24771ff4cbb",
+        "rev": "2b9504d5a0169d4940a312abe2df2c5658db8de9",
         "type": "github"
       },
       "original": {
@@ -241,11 +241,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1771834715,
-        "narHash": "sha256-5VI2KiMifx3Dca7nDJzctO3HpnS6zrvesdkLoZBrQRY=",
+        "lastModified": 1772216104,
+        "narHash": "sha256-1TnGN26vnCEQk5m4AavJZxGZTb/6aZyphemRPRwFUfs=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "b798c53da0f7e521317a5413335096a21070cf0b",
+        "rev": "dbe5112de965bbbbff9f0729a9789c20a65ab047",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1772433332,
+        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
         "type": "github"
       },
       "original": {
@@ -319,11 +319,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1771704400,
-        "narHash": "sha256-8U9xnN4HdxPfAXAft3lBsArWSv1ZTTxJci1lOA/xpno=",
+        "lastModified": 1772483693,
+        "narHash": "sha256-sOq/GUSR0uw1eQla0Wc5BKztPqBJBj3khd/GhaVg4xU=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "5c38b357da7e8c870350cd1847fb5b2602a28eb0",
+        "rev": "750dbfaf6eb62db8e67afc03a3ae3078bfd8f098",
         "type": "github"
       },
       "original": {
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770726378,
-        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
+        "lastModified": 1771858127,
+        "narHash": "sha256-Gtre9YoYl3n25tJH2AoSdjuwcqij5CPxL3U3xysYD08=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
+        "rev": "49bbbfc218bf3856dfa631cead3b052d78248b83",
         "type": "github"
       },
       "original": {
@@ -377,11 +377,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771125043,
-        "narHash": "sha256-ldf/s49n6rOAxl7pYLJGGS1N/assoHkCOWdEdLyNZkc=",
+        "lastModified": 1771988922,
+        "narHash": "sha256-Fc6FHXtfEkLtuVJzd0B6tFYMhmcPLuxr90rWfb/2jtQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4912f951a26dc8142b176be2c2ad834319dc06e8",
+        "rev": "f4443dc3f0b6c5e6b77d923156943ce816d1fcb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/6a7fdcd5839ec8b135821179eea3b58092171bcf?narHash=sha256-9SeTZ4Pwr730YfT7V8Azb8GFbwk1ZwiQDAwft3qAD%2Bo%3D' (2026-02-19)
  → 'github:nix-darwin/nix-darwin/52d061516108769656a8bd9c6e811c677ec5b462?narHash=sha256-NG9LLTWlz4YiaTAiRGChbrzbVxBfX%2BAuq4Ab/SWmk4A%3D' (2026-03-01)
• Updated input 'disko':
    'github:nix-community/disko/4707eec8d1d2db5182ea06ed48c820a86a42dc13?narHash=sha256-GnqdqhrguKNN3HtVfl6z%2BzbV9R9jhHFm3Z8nu7R6ml0%3D' (2026-02-19)
  → 'github:nix-community/disko/5af7af10f14706e4095bd6bc0d9373eb097283c6?narHash=sha256-naZz40TUFMa0E0CutvwWsSPhgD5JldyTUDEgP9ADpfU%3D' (2026-03-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5bd3589390b431a63072868a90c0f24771ff4cbb?narHash=sha256-Tl2I0YXdhSTufGqAaD1ySh8x%2BcvVsEI1mJyJg12lxhI%3D' (2026-02-22)
  → 'github:nix-community/home-manager/2b9504d5a0169d4940a312abe2df2c5658db8de9?narHash=sha256-2r4cKdqCVlQkvcTcLUMxmsmAYZZxCMd//w/PnDnukTE%3D' (2026-03-03)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/b798c53da0f7e521317a5413335096a21070cf0b?narHash=sha256-5VI2KiMifx3Dca7nDJzctO3HpnS6zrvesdkLoZBrQRY%3D' (2026-02-23)
  → 'github:nix-community/lanzaboote/dbe5112de965bbbbff9f0729a9789c20a65ab047?narHash=sha256-1TnGN26vnCEQk5m4AavJZxGZTb/6aZyphemRPRwFUfs%3D' (2026-02-27)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/a2812c19f1ed2e5ed5ce2ef7109798b575c180e1?narHash=sha256-aIlv7FRXF9q70DNJPI237dEDAznSKaXmL5lfK/Id/bI%3D' (2026-02-15)
  → 'github:ipetkov/crane/3d3de3313e263e04894f284ac18177bd26169bad?narHash=sha256-9bCDuUzpwJXcHMQYMS1yNuzYMmKO/CCwCexpjWOl62I%3D' (2026-02-22)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/5eaaedde414f6eb1aea8b8525c466dc37bba95ae?narHash=sha256-kck%2BvIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8%3D' (2026-02-10)
  → 'github:cachix/pre-commit-hooks.nix/49bbbfc218bf3856dfa631cead3b052d78248b83?narHash=sha256-Gtre9YoYl3n25tJH2AoSdjuwcqij5CPxL3U3xysYD08%3D' (2026-02-23)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/4912f951a26dc8142b176be2c2ad834319dc06e8?narHash=sha256-ldf/s49n6rOAxl7pYLJGGS1N/assoHkCOWdEdLyNZkc%3D' (2026-02-15)
  → 'github:oxalica/rust-overlay/f4443dc3f0b6c5e6b77d923156943ce816d1fcb9?narHash=sha256-Fc6FHXtfEkLtuVJzd0B6tFYMhmcPLuxr90rWfb/2jtQ%3D' (2026-02-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0182a361324364ae3f436a63005877674cf45efb?narHash=sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ%3D' (2026-02-17)
  → 'github:nixos/nixpkgs/cf59864ef8aa2e178cccedbe2c178185b0365705?narHash=sha256-izhTDFKsg6KeVBxJS9EblGeQ8y%2BO8eCa6RcW874vxEc%3D' (2026-03-02)
• Updated input 'nvf':
    'github:notashelf/nvf/5c38b357da7e8c870350cd1847fb5b2602a28eb0?narHash=sha256-8U9xnN4HdxPfAXAft3lBsArWSv1ZTTxJci1lOA/xpno%3D' (2026-02-21)
  → 'github:notashelf/nvf/750dbfaf6eb62db8e67afc03a3ae3078bfd8f098?narHash=sha256-sOq/GUSR0uw1eQla0Wc5BKztPqBJBj3khd/GhaVg4xU%3D' (2026-03-02)
```