### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1776635034,
-        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
+        "lastModified": 1777242778,
+        "narHash": "sha256-VWTeqWeb8Sel/QiWyaPvCa9luAbcGawR+Rw09FJoHz0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
+        "rev": "ad8b31ad0ba8448bd958d7a5d50d811dc5d271c0",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777298666,
-        "narHash": "sha256-3v+vue1Qkhr+oQxh3D7nhN6WSgDsBSnoviM8Xdb8TlI=",
+        "lastModified": 1777313591,
+        "narHash": "sha256-2sOhUm2EUZnyJqFp3UV1VmF4XjTfbhLm9KytHvChPrU=",
         "owner": "tlvince",
         "repo": "ghostwriter",
-        "rev": "e1e34d84968735532f542a98d05af19516b3a745",
+        "rev": "9d977524f2aa9abd509a20a6e5a8e197a464786e",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777151655,
-        "narHash": "sha256-Th3a5OZyEy4kCoyLfefnt+2dwRIrFQqYgMsayF9qzFw=",
+        "lastModified": 1777594677,
+        "narHash": "sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6f59831b23d03bbf4fbd13ad167ae25da294cc14",
+        "rev": "899c08a15beae5da51a5cecd6b2b994777a948da",
         "type": "github"
       },
       "original": {
@@ -261,11 +261,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1776797459,
-        "narHash": "sha256-utv296Xwk0PwjONe9dsyKx+9Z5xAB70aAsMI//aakpg=",
+        "lastModified": 1777299656,
+        "narHash": "sha256-c0r3xXp2+xFJwkryS+nhyQwoACbFzSt4C1TVs3QMh8E=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "4eda91dd5abd2157a2c7bfb33142fc64da668b0a",
+        "rev": "079c608988c2747db3902c9de033572cd50e8656",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -355,11 +355,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1777150561,
-        "narHash": "sha256-YLVqyn6LpFa+h697TmZIk0qVIbe7MxMpL8UTF4K+efA=",
+        "lastModified": 1777478067,
+        "narHash": "sha256-2vZnUuv8fg2sIE6pXgGxZQQ3ZhQW1XE7Sxieg8gK2p4=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "5b4f9c63205e5b0ef180a2b0e4cc844111f96fa6",
+        "rev": "13c4ad4b4bb926c22945e2fb8862769fe51f27f1",
         "type": "github"
       },
       "original": {
@@ -378,11 +378,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776741231,
-        "narHash": "sha256-k9G98qzn+7npROUaks8VqCFm7cFtEG8ulQLBBo5lItg=",
+        "lastModified": 1777173302,
+        "narHash": "sha256-ERiu3cbxvnTDxiDcimRA7af7xp6x1y0sRyLGm28Qzz8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "02061303f7c4c964f7b4584dabd9e985b4cd442b",
+        "rev": "aaec8c50baeaf2f2ba653e8aae71778a2bbbac94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'ghostwriter':
    'github:tlvince/ghostwriter/e1e34d84968735532f542a98d05af19516b3a745?narHash=sha256-3v%2Bvue1Qkhr%2BoQxh3D7nhN6WSgDsBSnoviM8Xdb8TlI%3D' (2026-04-27)
  → 'github:tlvince/ghostwriter/9d977524f2aa9abd509a20a6e5a8e197a464786e?narHash=sha256-2sOhUm2EUZnyJqFp3UV1VmF4XjTfbhLm9KytHvChPrU%3D' (2026-04-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6f59831b23d03bbf4fbd13ad167ae25da294cc14?narHash=sha256-Th3a5OZyEy4kCoyLfefnt%2B2dwRIrFQqYgMsayF9qzFw%3D' (2026-04-25)
  → 'github:nix-community/home-manager/899c08a15beae5da51a5cecd6b2b994777a948da?narHash=sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI%3D' (2026-05-01)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/4eda91dd5abd2157a2c7bfb33142fc64da668b0a?narHash=sha256-utv296Xwk0PwjONe9dsyKx%2B9Z5xAB70aAsMI//aakpg%3D' (2026-04-21)
  → 'github:nix-community/lanzaboote/079c608988c2747db3902c9de033572cd50e8656?narHash=sha256-c0r3xXp2%2BxFJwkryS%2BnhyQwoACbFzSt4C1TVs3QMh8E%3D' (2026-04-27)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/dc7496d8ea6e526b1254b55d09b966e94673750f?narHash=sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU%3D' (2026-04-19)
  → 'github:ipetkov/crane/ad8b31ad0ba8448bd958d7a5d50d811dc5d271c0?narHash=sha256-VWTeqWeb8Sel/QiWyaPvCa9luAbcGawR%2BRw09FJoHz0%3D' (2026-04-26)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/580633fa3fe5fc0379905986543fd7495481913d?narHash=sha256-8Psjt%2BTWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4%3D' (2026-04-07)
  → 'github:cachix/pre-commit-hooks.nix/3cfd774b0a530725a077e17354fbdb87ea1c4aad?narHash=sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8%3D' (2026-04-21)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/02061303f7c4c964f7b4584dabd9e985b4cd442b?narHash=sha256-k9G98qzn%2B7npROUaks8VqCFm7cFtEG8ulQLBBo5lItg%3D' (2026-04-21)
  → 'github:oxalica/rust-overlay/aaec8c50baeaf2f2ba653e8aae71778a2bbbac94?narHash=sha256-ERiu3cbxvnTDxiDcimRA7af7xp6x1y0sRyLGm28Qzz8%3D' (2026-04-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0726a0ecb6d4e08f6adced58726b95db924cef57?narHash=sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI%3D' (2026-04-22)
  → 'github:nixos/nixpkgs/1c3fe55ad329cbcb28471bb30f05c9827f724c76?narHash=sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M%2BC8yzzIRYbE%3D' (2026-04-27)
• Updated input 'nvf':
    'github:notashelf/nvf/5b4f9c63205e5b0ef180a2b0e4cc844111f96fa6?narHash=sha256-YLVqyn6LpFa%2Bh697TmZIk0qVIbe7MxMpL8UTF4K%2BefA%3D' (2026-04-25)
  → 'github:notashelf/nvf/13c4ad4b4bb926c22945e2fb8862769fe51f27f1?narHash=sha256-2vZnUuv8fg2sIE6pXgGxZQQ3ZhQW1XE7Sxieg8gK2p4%3D' (2026-04-29)
```