### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1777242778,
-        "narHash": "sha256-VWTeqWeb8Sel/QiWyaPvCa9luAbcGawR+Rw09FJoHz0=",
+        "lastModified": 1777830388,
+        "narHash": "sha256-2uoQAqUk2H0ijQtGiWAyNeQYGYc6yfAcRRLlJAz4Gp8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "ad8b31ad0ba8448bd958d7a5d50d811dc5d271c0",
+        "rev": "d459c1350e96ce1a7e3859c513ef5e9869d67d6f",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1777780666,
+        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777594677,
-        "narHash": "sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI=",
+        "lastModified": 1777988791,
+        "narHash": "sha256-DtbtSW5+Hls7z+D9BfsAXvFuivt5iZ0OzUXjQ8d8lB8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "899c08a15beae5da51a5cecd6b2b994777a948da",
+        "rev": "d987617879f613053f6fdf4491fe28ce0283d543",
         "type": "github"
       },
       "original": {
@@ -261,11 +261,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777299656,
-        "narHash": "sha256-c0r3xXp2+xFJwkryS+nhyQwoACbFzSt4C1TVs3QMh8E=",
+        "lastModified": 1777882242,
+        "narHash": "sha256-9Ynx+ort1aSwReiCfkbgMS3Q6y+MPcekDoUWx9N3a7A=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "079c608988c2747db3902c9de033572cd50e8656",
+        "rev": "04723d4fd6bde2665fef3b25856aeebbd4013c16",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "mnw": {
       "locked": {
-        "lastModified": 1770419553,
-        "narHash": "sha256-b1XqsH7AtVf2dXmq2iyRr2NC1yG7skY7Z6N2MpWHlK4=",
+        "lastModified": 1777828893,
+        "narHash": "sha256-gVWVnmyNr74BVKfhMMZDWkhx2699dhmZ2g0W8TTHtkk=",
         "owner": "Gerg-L",
         "repo": "mnw",
-        "rev": "2aaffa8030d0b262176146adbb6b0e6374ce2957",
+        "rev": "c1c0b544bfabe6669b5a6a0383ccb475fe60258b",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
@@ -355,11 +355,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1777478067,
-        "narHash": "sha256-2vZnUuv8fg2sIE6pXgGxZQQ3ZhQW1XE7Sxieg8gK2p4=",
+        "lastModified": 1777963724,
+        "narHash": "sha256-DM3sF8ikMrqPGapSOpYYtwqfYMU/xDaP/UzmmdC0lgI=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "13c4ad4b4bb926c22945e2fb8862769fe51f27f1",
+        "rev": "5dc8f3a34cf46d98f6a0073368adc2746b854cf6",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777173302,
-        "narHash": "sha256-ERiu3cbxvnTDxiDcimRA7af7xp6x1y0sRyLGm28Qzz8=",
+        "lastModified": 1777778183,
+        "narHash": "sha256-Lqv9MZO0XAGcMbXJU+ULBSMD41Pf391uJehylUQKe7Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "aaec8c50baeaf2f2ba653e8aae71778a2bbbac94",
+        "rev": "dbba5f888c82ef3ce594c451c33ac2474eb80847",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/06648f4902343228ce2de79f291dd5a58ee12146?narHash=sha256-KM2WYj6EA7M/FVZVCl3rqWY%2BTFV5QzSyyGE2gQxeODU%3D' (2026-04-01)
  → 'github:nix-darwin/nix-darwin/8c62fba0854ba15c8917aed18894dbccb48a3777?narHash=sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE%3D' (2026-05-03)
• Updated input 'disko':
    'github:nix-community/disko/32f4236bfc141ae930b5ba2fb604f561fed5219d?narHash=sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI%3D' (2026-04-19)
  → 'github:nix-community/disko/63b4e7e6cf75307c1d26ac3762b886b5b0247267?narHash=sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo%3D' (2026-05-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/899c08a15beae5da51a5cecd6b2b994777a948da?narHash=sha256-h90sHwoRJLRvaTpZroTvU2JRHDFj0czUafM8eqLe1RI%3D' (2026-05-01)
  → 'github:nix-community/home-manager/d987617879f613053f6fdf4491fe28ce0283d543?narHash=sha256-DtbtSW5%2BHls7z%2BD9BfsAXvFuivt5iZ0OzUXjQ8d8lB8%3D' (2026-05-05)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/079c608988c2747db3902c9de033572cd50e8656?narHash=sha256-c0r3xXp2%2BxFJwkryS%2BnhyQwoACbFzSt4C1TVs3QMh8E%3D' (2026-04-27)
  → 'github:nix-community/lanzaboote/04723d4fd6bde2665fef3b25856aeebbd4013c16?narHash=sha256-9Ynx%2Bort1aSwReiCfkbgMS3Q6y%2BMPcekDoUWx9N3a7A%3D' (2026-05-04)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/ad8b31ad0ba8448bd958d7a5d50d811dc5d271c0?narHash=sha256-VWTeqWeb8Sel/QiWyaPvCa9luAbcGawR%2BRw09FJoHz0%3D' (2026-04-26)
  → 'github:ipetkov/crane/d459c1350e96ce1a7e3859c513ef5e9869d67d6f?narHash=sha256-2uoQAqUk2H0ijQtGiWAyNeQYGYc6yfAcRRLlJAz4Gp8%3D' (2026-05-03)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/aaec8c50baeaf2f2ba653e8aae71778a2bbbac94?narHash=sha256-ERiu3cbxvnTDxiDcimRA7af7xp6x1y0sRyLGm28Qzz8%3D' (2026-04-26)
  → 'github:oxalica/rust-overlay/dbba5f888c82ef3ce594c451c33ac2474eb80847?narHash=sha256-Lqv9MZO0XAGcMbXJU%2BULBSMD41Pf391uJehylUQKe7Y%3D' (2026-05-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1c3fe55ad329cbcb28471bb30f05c9827f724c76?narHash=sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M%2BC8yzzIRYbE%3D' (2026-04-27)
  → 'github:nixos/nixpkgs/549bd84d6279f9852cae6225e372cc67fb91a4c1?narHash=sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9%2BhrDTkDU%3D' (2026-05-05)
• Updated input 'nvf':
    'github:notashelf/nvf/13c4ad4b4bb926c22945e2fb8862769fe51f27f1?narHash=sha256-2vZnUuv8fg2sIE6pXgGxZQQ3ZhQW1XE7Sxieg8gK2p4%3D' (2026-04-29)
  → 'github:notashelf/nvf/5dc8f3a34cf46d98f6a0073368adc2746b854cf6?narHash=sha256-DM3sF8ikMrqPGapSOpYYtwqfYMU/xDaP/UzmmdC0lgI%3D' (2026-05-05)
• Updated input 'nvf/mnw':
    'github:Gerg-L/mnw/2aaffa8030d0b262176146adbb6b0e6374ce2957?narHash=sha256-b1XqsH7AtVf2dXmq2iyRr2NC1yG7skY7Z6N2MpWHlK4%3D' (2026-02-06)
  → 'github:Gerg-L/mnw/c1c0b544bfabe6669b5a6a0383ccb475fe60258b?narHash=sha256-gVWVnmyNr74BVKfhMMZDWkhx2699dhmZ2g0W8TTHtkk%3D' (2026-05-03)
```