### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1779041105,
-        "narHash": "sha256-nnGD2f8OlAZT2i5OfwikJsw+ifWfiA4d6A8BWlgOXV0=",
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "10e6e3cb966f7cfcc789fe5eee7a85f3188ce08b",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779226674,
-        "narHash": "sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs=",
+        "lastModified": 1779699611,
+        "narHash": "sha256-EcCaSTKnmg2o4wLKaN1aqQFomwyhO7ik0bX9COdyCas=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "65fb947964bd44fc0008faf77d1fcb7a9f40bb32",
+        "rev": "5ba0c9555c28685e57fa54c7a25e42c7efdbfc8d",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779592288,
-        "narHash": "sha256-pVZwRFVFdHS3D3G07MiZQcSPENnv1xlYCJtfabkqd3Q=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "23703a32ef3d7803a2f1bb9909a3f46fc5185e37",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -261,11 +261,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779135966,
-        "narHash": "sha256-FHKdAxS5TJ0mdNS/9YuIam7NGtzEXVggLEWQ00Q31yc=",
+        "lastModified": 1779865172,
+        "narHash": "sha256-QZuox/4ww6vOmUu9lCpKlQbU3MER1kmgnJmXP1LO1K0=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "b7e492b90bcae5e9d9cb0a1d4d1e6100305de2c5",
+        "rev": "f42b84f9fb03db98dee2073e932010f3a76eeb9a",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779074409,
-        "narHash": "sha256-6aXy8Ga41iLVM8ibddFU1O5+wYWcBGNEfZzZuL91eIc=",
+        "lastModified": 1779592685,
+        "narHash": "sha256-p9d56GezhHRf4QfANxwa1d+fvwShvjB5XUhdIl7WEd0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2a77b5b1dc952f214e8102acdef1622b68515560",
+        "rev": "3a58b199e7c83a80b85c28044f808085ba7e941c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/65fb947964bd44fc0008faf77d1fcb7a9f40bb32?narHash=sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs%3D' (2026-05-19)
  → 'github:nix-community/disko/5ba0c9555c28685e57fa54c7a25e42c7efdbfc8d?narHash=sha256-EcCaSTKnmg2o4wLKaN1aqQFomwyhO7ik0bX9COdyCas%3D' (2026-05-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/23703a32ef3d7803a2f1bb9909a3f46fc5185e37?narHash=sha256-pVZwRFVFdHS3D3G07MiZQcSPENnv1xlYCJtfabkqd3Q%3D' (2026-05-24)
  → 'github:nix-community/home-manager/1a95e2efb477959b70b4a14c51035975c0481df6?narHash=sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA%3D' (2026-05-25)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/b7e492b90bcae5e9d9cb0a1d4d1e6100305de2c5?narHash=sha256-FHKdAxS5TJ0mdNS/9YuIam7NGtzEXVggLEWQ00Q31yc%3D' (2026-05-18)
  → 'github:nix-community/lanzaboote/f42b84f9fb03db98dee2073e932010f3a76eeb9a?narHash=sha256-QZuox/4ww6vOmUu9lCpKlQbU3MER1kmgnJmXP1LO1K0%3D' (2026-05-27)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/10e6e3cb966f7cfcc789fe5eee7a85f3188ce08b?narHash=sha256-nnGD2f8OlAZT2i5OfwikJsw%2BifWfiA4d6A8BWlgOXV0%3D' (2026-05-17)
  → 'github:ipetkov/crane/edb38893982a3338972bb4a2ec7ce7c29ba10fd9?narHash=sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ%3D' (2026-05-18)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/2a77b5b1dc952f214e8102acdef1622b68515560?narHash=sha256-6aXy8Ga41iLVM8ibddFU1O5%2BwYWcBGNEfZzZuL91eIc%3D' (2026-05-18)
  → 'github:oxalica/rust-overlay/3a58b199e7c83a80b85c28044f808085ba7e941c?narHash=sha256-p9d56GezhHRf4QfANxwa1d%2BfvwShvjB5XUhdIl7WEd0%3D' (2026-05-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/29916453413845e54a65b8a1cf996842300cd299?narHash=sha256-Ap9KJX%2B5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M%3D' (2026-05-23)
  → 'github:nixos/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
```