### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1779130139,
-        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1781242433,
+        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779699611,
-        "narHash": "sha256-EcCaSTKnmg2o4wLKaN1aqQFomwyhO7ik0bX9COdyCas=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5ba0c9555c28685e57fa54c7a25e42c7efdbfc8d",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726696,
-        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
+        "lastModified": 1781497404,
+        "narHash": "sha256-9GAF8sSsnkyCVCWkomXR0T+zdSxyUlfPt6neQidimdg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
+        "rev": "1285cd3d6882a9847f2d56ed5541b3350c8a6162",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     },
     "jail-nix": {
       "locked": {
-        "lastModified": 1772137954,
-        "narHash": "sha256-h4MGNbOo7L3RHi4uNFmsg5g17/DHXEfnv/xiG6BrNFQ=",
+        "lastModified": 1776230864,
+        "narHash": "sha256-YsEjjdOsGEzTeD+iT7ONh071BqWAOQWpzYVei3okAXE=",
         "owner": "~alexdavid",
         "repo": "jail.nix",
-        "rev": "42b355c38ca63dab4904acc5c0d95f17954a8c9b",
+        "rev": "404e7da9da5ab9aa643666682b2ba1312fa5fbe8",
         "type": "sourcehut"
       },
       "original": {
@@ -261,11 +261,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779865172,
-        "narHash": "sha256-QZuox/4ww6vOmUu9lCpKlQbU3MER1kmgnJmXP1LO1K0=",
+        "lastModified": 1781181476,
+        "narHash": "sha256-4JLkQvN7/f77TyxXXtoEuUfovMqMLOgWpBaLMNX1dns=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f42b84f9fb03db98dee2073e932010f3a76eeb9a",
+        "rev": "0403b4b7e8b2612657f0053a4c315e6c43eee9e6",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "mnw": {
       "locked": {
-        "lastModified": 1778541201,
-        "narHash": "sha256-n0twkzWexzjsoDycOTvvQNuGEdg62UiNHYcFCduYpKI=",
+        "lastModified": 1780772958,
+        "narHash": "sha256-VKKe8r4pwCGWZ3Yr9CPN129R4S3CKLSrlYqdYz3vKpM=",
         "owner": "Gerg-L",
         "repo": "mnw",
-        "rev": "1a3573fc9d2486738fe0b2cacc5cd10dd5f3a445",
+        "rev": "0871dbf63a53610c95db04439ed8ea4d6ec9c160",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -355,11 +355,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1779461836,
-        "narHash": "sha256-iV6reLT7o1XfofI+mLuFZl7TdDXzsnniXge6aFXjjrc=",
+        "lastModified": 1781468924,
+        "narHash": "sha256-lohnpykCw/3ABFIyMw3SjKQe+Je3iiH/ZHAl/HOS00s=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "21849b62be17c6657accbf4e0c9e1afe57e27ea3",
+        "rev": "d55e51c3f75b94f49445a9efb73aab722df1cf4d",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779592685,
-        "narHash": "sha256-p9d56GezhHRf4QfANxwa1d+fvwShvjB5XUhdIl7WEd0=",
+        "lastModified": 1780802404,
+        "narHash": "sha256-bGtIUeLb0yChX4h6hB40OOCwcYhcpQZHXSDvZGdWgeM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3a58b199e7c83a80b85c28044f808085ba7e941c",
+        "rev": "8e596a8430f2ce54d55c742198187d6945a5501e",
         "type": "github"
       },
       "original": {

--- a/hosts/lamma.nix
+++ b/hosts/lamma.nix
@@ -21,19 +21,6 @@
   };
 
   nixpkgs.hostPlatform = "aarch64-darwin";
-  nixpkgs.overlays = [
-    (final: prev: {
-      # TODO: Remove mactop overlay
-      # Issue URL: https://github.com/tlvince/nixos-config/issues/451
-      # Build fails as of 2.0.5, see:
-      # https://github.com/NixOS/nixpkgs/issues/483467
-      # https://github.com/NixOS/nixpkgs/pull/477686
-      # labels: host:lamma
-      mactop = prev.mactop.overrideAttrs (old: {
-        doCheck = false;
-      });
-    })
-  ];
 
   security.pam.services.sudo_local.touchIdAuth = true;
 


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/56c666e108467d87d13508936aade6d567f2a501?narHash=sha256-zXcwYQGCT6pzinK%2B1dBB2ekTVtfxGZAapb3Evdcu4fY%3D' (2026-05-17)
  → 'github:nix-darwin/nix-darwin/aabb2037edfc0f210723b72cd5f528aab5dd3f0b?narHash=sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO%2BE%3D' (2026-06-12)
• Updated input 'disko':
    'github:nix-community/disko/5ba0c9555c28685e57fa54c7a25e42c7efdbfc8d?narHash=sha256-EcCaSTKnmg2o4wLKaN1aqQFomwyhO7ik0bX9COdyCas%3D' (2026-05-25)
  → 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1?narHash=sha256-RxWs5ND31KzTG7wvMM%2BPMfUjyNpmIEr999lqNARaM5o%3D' (2026-06-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1a95e2efb477959b70b4a14c51035975c0481df6?narHash=sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA%3D' (2026-05-25)
  → 'github:nix-community/home-manager/1285cd3d6882a9847f2d56ed5541b3350c8a6162?narHash=sha256-9GAF8sSsnkyCVCWkomXR0T%2BzdSxyUlfPt6neQidimdg%3D' (2026-06-15)
• Updated input 'jail-nix':
    'sourcehut:~alexdavid/jail.nix/42b355c38ca63dab4904acc5c0d95f17954a8c9b?narHash=sha256-h4MGNbOo7L3RHi4uNFmsg5g17/DHXEfnv/xiG6BrNFQ%3D' (2026-02-26)
  → 'sourcehut:~alexdavid/jail.nix/404e7da9da5ab9aa643666682b2ba1312fa5fbe8?narHash=sha256-YsEjjdOsGEzTeD%2BiT7ONh071BqWAOQWpzYVei3okAXE%3D' (2026-04-15)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/f42b84f9fb03db98dee2073e932010f3a76eeb9a?narHash=sha256-QZuox/4ww6vOmUu9lCpKlQbU3MER1kmgnJmXP1LO1K0%3D' (2026-05-27)
  → 'github:nix-community/lanzaboote/0403b4b7e8b2612657f0053a4c315e6c43eee9e6?narHash=sha256-4JLkQvN7/f77TyxXXtoEuUfovMqMLOgWpBaLMNX1dns%3D' (2026-06-11)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/edb38893982a3338972bb4a2ec7ce7c29ba10fd9?narHash=sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ%3D' (2026-05-18)
  → 'github:ipetkov/crane/59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37?narHash=sha256-D%2BBsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0%3D' (2026-06-04)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/3a58b199e7c83a80b85c28044f808085ba7e941c?narHash=sha256-p9d56GezhHRf4QfANxwa1d%2BfvwShvjB5XUhdIl7WEd0%3D' (2026-05-24)
  → 'github:oxalica/rust-overlay/8e596a8430f2ce54d55c742198187d6945a5501e?narHash=sha256-bGtIUeLb0yChX4h6hB40OOCwcYhcpQZHXSDvZGdWgeM%3D' (2026-06-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
  → 'github:nixos/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)
• Updated input 'nvf':
    'github:notashelf/nvf/21849b62be17c6657accbf4e0c9e1afe57e27ea3?narHash=sha256-iV6reLT7o1XfofI%2BmLuFZl7TdDXzsnniXge6aFXjjrc%3D' (2026-05-22)
  → 'github:notashelf/nvf/d55e51c3f75b94f49445a9efb73aab722df1cf4d?narHash=sha256-lohnpykCw/3ABFIyMw3SjKQe%2BJe3iiH/ZHAl/HOS00s%3D' (2026-06-14)
• Updated input 'nvf/mnw':
    'github:Gerg-L/mnw/1a3573fc9d2486738fe0b2cacc5cd10dd5f3a445?narHash=sha256-n0twkzWexzjsoDycOTvvQNuGEdg62UiNHYcFCduYpKI%3D' (2026-05-11)
  → 'github:Gerg-L/mnw/0871dbf63a53610c95db04439ed8ea4d6ec9c160?narHash=sha256-VKKe8r4pwCGWZ3Yr9CPN129R4S3CKLSrlYqdYz3vKpM%3D' (2026-06-06)
```