### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1783203018,
-        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
+        "lastModified": 1784407669,
+        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
+        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783395956,
-        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783823409,
-        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
+        "lastModified": 1784789275,
+        "narHash": "sha256-cgRTWuG+u1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
+        "rev": "3b0e6bbd65869af1beadf5963a99befc179d209f",
         "type": "github"
       },
       "original": {
@@ -218,11 +218,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1783496806,
-        "narHash": "sha256-6B6CQUk1dPc8l/+otaGiYbuX8qeX/0VmSUQ+qSn0/uA=",
+        "lastModified": 1784568171,
+        "narHash": "sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "6183ac79eadb079a1e72fa2c60915601be669100",
+        "rev": "f4b0aef3dba28677a5ca4b3416827aade60b5a0b",
         "type": "github"
       },
       "original": {
@@ -248,11 +248,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783928475,
-        "narHash": "sha256-pzFTGMkhIzV2kpn8MP/BdAVfSF2hM1YwZOCKEW2AhOw=",
+        "lastModified": 1784703826,
+        "narHash": "sha256-YfZIcpd+bqApvv35t1HuxlyGWGo/doCSxv9kgz/lQHA=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "e84c13bfb2a9b242e07b486f67ff925b29338293",
+        "rev": "0015a23ce7ce0ac59b08245a0010de690fb7fe81",
         "type": "github"
       },
       "original": {
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -346,11 +346,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783488441,
-        "narHash": "sha256-jmWf+H3iC/0z7/mmvTovaJx1E/LME1QyHkyk+AFfJPk=",
+        "lastModified": 1784438913,
+        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7dc3a177a239ed879c5581a80f6dc246c7e102f1",
+        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/d5bd9cd77aea4c0a8f49e7fd85545671a208ed15?narHash=sha256-AAbexQvDoK%2B6GFJdhY6kqjA%2B6ECKRkidgWxkn4gMwAA%3D' (2026-07-07)
  → 'github:nix-darwin/nix-darwin/57a3171f94705599a2499248ca5758d5eb47c0e0?narHash=sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo%3D' (2026-07-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/7566825d4652a1b885bd4ce65bd9e8def432fec9?narHash=sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI%3D' (2026-07-12)
  → 'github:nix-community/home-manager/3b0e6bbd65869af1beadf5963a99befc179d209f?narHash=sha256-cgRTWuG%2Bu1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M%3D' (2026-07-23)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/6183ac79eadb079a1e72fa2c60915601be669100?narHash=sha256-6B6CQUk1dPc8l/%2BotaGiYbuX8qeX/0VmSUQ%2BqSn0/uA%3D' (2026-07-08)
  → 'github:nix-community/lanzaboote/f4b0aef3dba28677a5ca4b3416827aade60b5a0b?narHash=sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ%3D' (2026-07-20)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/80db5bdc391be8a1794f6d8a2d56e3a84ebcede2?narHash=sha256-G6R9IT/xwFuu%2BCYBWDUAok6AdC4ERC4ZfPPFtEpxnZE%3D' (2026-07-04)
  → 'github:ipetkov/crane/1316b7d278ad77a16aec024b71d971366e123bec?narHash=sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6%2Bo%3D' (2026-07-18)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/git-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe?narHash=sha256-jGiy6%2BsxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ%3D' (2026-07-02)
  → 'github:cachix/git-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9?narHash=sha256-ReRHaLgr/uVqdD8afFSn%2BmyXIfpHeOhP0yYe0TJqAA8%3D' (2026-07-17)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/7dc3a177a239ed879c5581a80f6dc246c7e102f1?narHash=sha256-jmWf%2BH3iC/0z7/mmvTovaJx1E/LME1QyHkyk%2BAFfJPk%3D' (2026-07-08)
  → 'github:oxalica/rust-overlay/afacd6819d3765a05814ee8e3de74c77d42ac799?narHash=sha256-NYF7ZM5ip0u%2Bw1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw%3D' (2026-07-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3?narHash=sha256-UgCQzxeWI75XM8G%2BhPrPh%2BMKzEPjG3SpAj7dtqSbksA%3D' (2026-07-11)
  → 'github:nixos/nixpkgs/241313f4e8e508cb9b13278c2b0fa25b9ca27163?narHash=sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU%3D' (2026-07-19)
• Updated input 'nvf':
    'github:notashelf/nvf/e84c13bfb2a9b242e07b486f67ff925b29338293?narHash=sha256-pzFTGMkhIzV2kpn8MP/BdAVfSF2hM1YwZOCKEW2AhOw%3D' (2026-07-13)
  → 'github:notashelf/nvf/0015a23ce7ce0ac59b08245a0010de690fb7fe81?narHash=sha256-YfZIcpd%2BbqApvv35t1HuxlyGWGo/doCSxv9kgz/lQHA%3D' (2026-07-22)
```