### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1784407669,
-        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
+        "lastModified": 1784564969,
+        "narHash": "sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy+oJe4PUiXg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
+        "rev": "7930f6c291de6f83c257839d434592aa085f290a",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784500460,
-        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
+        "lastModified": 1785389976,
+        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
+        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785119578,
-        "narHash": "sha256-3VMVuOJ6fK+RNOXVmqusqUwQ1sDfPeddNKaM2JR/4Y0=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e83dffa86cccb6237fe194d4eeb47f41557749d1",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1784568171,
-        "narHash": "sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ=",
+        "lastModified": 1785452604,
+        "narHash": "sha256-d0NKOOtI90kk8DAXNDkgYUZD8KK908bczz6zNLTC/zw=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f4b0aef3dba28677a5ca4b3416827aade60b5a0b",
+        "rev": "c191775376b8734af02970153b4e5d86841dff19",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785093145,
-        "narHash": "sha256-Wutqb+MbbcLqm03C6jKYjVVwAQPOtcUueVQv/B+3z5s=",
+        "lastModified": 1785524545,
+        "narHash": "sha256-ILww3rsO4JA9bY2pV56Pg/VrRADQmIw/alhpM4eUIYY=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "9851d9c3e0f32e7f37139893f16f6229929649fd",
+        "rev": "fbf73761f56c7b41f8095bd1a8fcadefea30a05b",
         "type": "github"
       },
       "original": {
@@ -367,11 +367,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784438913,
-        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
+        "lastModified": 1785044261,
+        "narHash": "sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
+        "rev": "fe2124391e739e7b3e8720cd8a73f06edd0aceba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/57a3171f94705599a2499248ca5758d5eb47c0e0?narHash=sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo%3D' (2026-07-19)
  → 'github:nix-darwin/nix-darwin/15abb8c98f336cd8bd840d71059adebabe60bf04?narHash=sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU%3D' (2026-07-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e83dffa86cccb6237fe194d4eeb47f41557749d1?narHash=sha256-3VMVuOJ6fK%2BRNOXVmqusqUwQ1sDfPeddNKaM2JR/4Y0%3D' (2026-07-27)
  → 'github:nix-community/home-manager/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe?narHash=sha256-vkMnV0JIyw%2Bg/NmcfoajlGaAO%2B9a0ezia%2BFZohQJrik%3D' (2026-07-31)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/f4b0aef3dba28677a5ca4b3416827aade60b5a0b?narHash=sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ%3D' (2026-07-20)
  → 'github:nix-community/lanzaboote/c191775376b8734af02970153b4e5d86841dff19?narHash=sha256-d0NKOOtI90kk8DAXNDkgYUZD8KK908bczz6zNLTC/zw%3D' (2026-07-30)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/1316b7d278ad77a16aec024b71d971366e123bec?narHash=sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6%2Bo%3D' (2026-07-18)
  → 'github:ipetkov/crane/7930f6c291de6f83c257839d434592aa085f290a?narHash=sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy%2BoJe4PUiXg%3D' (2026-07-20)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/afacd6819d3765a05814ee8e3de74c77d42ac799?narHash=sha256-NYF7ZM5ip0u%2Bw1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw%3D' (2026-07-19)
  → 'github:oxalica/rust-overlay/fe2124391e739e7b3e8720cd8a73f06edd0aceba?narHash=sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4%3D' (2026-07-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/624af665418d3c65d544145b4d34ad696439570e?narHash=sha256-m0pDuRJG7EDo9ri%2B4Ksu83VsI%2BPlxNC9lNBfydejce4%3D' (2026-07-26)
  → 'github:nixos/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
• Updated input 'nvf':
    'github:notashelf/nvf/9851d9c3e0f32e7f37139893f16f6229929649fd?narHash=sha256-Wutqb%2BMbbcLqm03C6jKYjVVwAQPOtcUueVQv/B%2B3z5s%3D' (2026-07-26)
  → 'github:notashelf/nvf/fbf73761f56c7b41f8095bd1a8fcadefea30a05b?narHash=sha256-ILww3rsO4JA9bY2pV56Pg/VrRADQmIw/alhpM4eUIYY%3D' (2026-07-31)
```