### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783979936,
-        "narHash": "sha256-4REe4iLlQbOFJ2ur2m8bPFuI/Tk5p/cBy3UPM3TNupY=",
+        "lastModified": 1785672383,
+        "narHash": "sha256-fFw7W2LvGX82c3Em0f05n54gL4xxRA0Lx6W1EOt6XBE=",
         "owner": "archie-judd",
         "repo": "agent-sandbox.nix",
-        "rev": "bab6b8a24348f0ca2063a48fdc7a98a526a522a3",
+        "rev": "601298adf27284004381b313a9dd46ea9ed9e06e",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1785452604,
-        "narHash": "sha256-d0NKOOtI90kk8DAXNDkgYUZD8KK908bczz6zNLTC/zw=",
+        "lastModified": 1785749642,
+        "narHash": "sha256-5/wlGe3a4ucxvYq2cuAAsuSFWKcIttQ6En83MLlV2jY=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "c191775376b8734af02970153b4e5d86841dff19",
+        "rev": "f142433bdbeffd2af51231e0aff7162c2bfbf6ef",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1785692966,
+        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785524545,
-        "narHash": "sha256-ILww3rsO4JA9bY2pV56Pg/VrRADQmIw/alhpM4eUIYY=",
+        "lastModified": 1785805913,
+        "narHash": "sha256-MWrMx8gFp6A/ueWDdT8mNM06G9Wh6GdFZlBBLdw/MQk=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "fbf73761f56c7b41f8095bd1a8fcadefea30a05b",
+        "rev": "118286cd362be3f31700e55ae21ef71d169d06ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'agent-sandbox':
    'github:archie-judd/agent-sandbox.nix/bab6b8a24348f0ca2063a48fdc7a98a526a522a3?narHash=sha256-4REe4iLlQbOFJ2ur2m8bPFuI/Tk5p/cBy3UPM3TNupY%3D' (2026-07-13)
  → 'github:archie-judd/agent-sandbox.nix/601298adf27284004381b313a9dd46ea9ed9e06e?narHash=sha256-fFw7W2LvGX82c3Em0f05n54gL4xxRA0Lx6W1EOt6XBE%3D' (2026-08-02)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/c191775376b8734af02970153b4e5d86841dff19?narHash=sha256-d0NKOOtI90kk8DAXNDkgYUZD8KK908bczz6zNLTC/zw%3D' (2026-07-30)
  → 'github:nix-community/lanzaboote/f142433bdbeffd2af51231e0aff7162c2bfbf6ef?narHash=sha256-5/wlGe3a4ucxvYq2cuAAsuSFWKcIttQ6En83MLlV2jY%3D' (2026-08-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
  → 'github:nixos/nixpkgs/643809054d65fdd466a63e3155b8c498cb483c04?narHash=sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk%3D' (2026-08-02)
• Updated input 'nvf':
    'github:notashelf/nvf/fbf73761f56c7b41f8095bd1a8fcadefea30a05b?narHash=sha256-ILww3rsO4JA9bY2pV56Pg/VrRADQmIw/alhpM4eUIYY%3D' (2026-07-31)
  → 'github:notashelf/nvf/118286cd362be3f31700e55ae21ef71d169d06ea?narHash=sha256-MWrMx8gFp6A/ueWDdT8mNM06G9Wh6GdFZlBBLdw/MQk%3D' (2026-08-04)
```