### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -78,11 +78,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1784564969,
-        "narHash": "sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy+oJe4PUiXg=",
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7930f6c291de6f83c257839d434592aa085f290a",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785531816,
-        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
+        "lastModified": 1786656209,
+        "narHash": "sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
+        "rev": "c554d3441f725537854e877519f01cbd60680174",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1785749642,
-        "narHash": "sha256-5/wlGe3a4ucxvYq2cuAAsuSFWKcIttQ6En83MLlV2jY=",
+        "lastModified": 1786473774,
+        "narHash": "sha256-BDedo9F6NJOw+Ii+luFZh0MVIheKqiYgiVzMWc6WB24=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f142433bdbeffd2af51231e0aff7162c2bfbf6ef",
+        "rev": "4a773989235545c56f408d168cb63bc41d468832",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786337855,
-        "narHash": "sha256-UG8v0D6MCJs7TCpdpAOLKus+IHktnt4MlV19kFLZQ2w=",
+        "lastModified": 1786696856,
+        "narHash": "sha256-9RrMhDtyppb3gqSTrPf+J9i6VrFgsDTmGShHTX0rQKA=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "33656317a15ef8171dc2efbbdefd5f7b092b57b9",
+        "rev": "1277ada3438f94a503a64f6535074ee2a106967f",
         "type": "github"
       },
       "original": {
@@ -346,11 +346,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785692966,
-        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785805913,
-        "narHash": "sha256-MWrMx8gFp6A/ueWDdT8mNM06G9Wh6GdFZlBBLdw/MQk=",
+        "lastModified": 1786433999,
+        "narHash": "sha256-rbOp2g0UCYt+evTnCGCKBQGqSMfwX4RTXneNbeHqOAk=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "118286cd362be3f31700e55ae21ef71d169d06ea",
+        "rev": "a213644cadd5f90bf18b0c409f08f282b30e55e3",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785044261,
-        "narHash": "sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4=",
+        "lastModified": 1786420161,
+        "narHash": "sha256-PU4CY4GUCDFOoS67dGrc/fS6Y+d1cYZSh6nbgYqAAwE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fe2124391e739e7b3e8720cd8a73f06edd0aceba",
+        "rev": "3a646bd5daa3af78a78a1cb32329cb72d18fcae0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe?narHash=sha256-vkMnV0JIyw%2Bg/NmcfoajlGaAO%2B9a0ezia%2BFZohQJrik%3D' (2026-07-31)
  → 'github:nix-community/home-manager/c554d3441f725537854e877519f01cbd60680174?narHash=sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA%3D' (2026-08-13)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/f142433bdbeffd2af51231e0aff7162c2bfbf6ef?narHash=sha256-5/wlGe3a4ucxvYq2cuAAsuSFWKcIttQ6En83MLlV2jY%3D' (2026-08-03)
  → 'github:nix-community/lanzaboote/4a773989235545c56f408d168cb63bc41d468832?narHash=sha256-BDedo9F6NJOw%2BIi%2BluFZh0MVIheKqiYgiVzMWc6WB24%3D' (2026-08-11)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/7930f6c291de6f83c257839d434592aa085f290a?narHash=sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy%2BoJe4PUiXg%3D' (2026-07-20)
  → 'github:ipetkov/crane/2c71e194474d13de031d729b729c968ddbe3507f?narHash=sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw%3D' (2026-08-03)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/fe2124391e739e7b3e8720cd8a73f06edd0aceba?narHash=sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4%3D' (2026-07-26)
  → 'github:oxalica/rust-overlay/3a646bd5daa3af78a78a1cb32329cb72d18fcae0?narHash=sha256-PU4CY4GUCDFOoS67dGrc/fS6Y%2Bd1cYZSh6nbgYqAAwE%3D' (2026-08-11)
• Updated input 'llm-agents':
    'github:numtide/llm-agents.nix/33656317a15ef8171dc2efbbdefd5f7b092b57b9?narHash=sha256-UG8v0D6MCJs7TCpdpAOLKus%2BIHktnt4MlV19kFLZQ2w%3D' (2026-08-10)
  → 'github:numtide/llm-agents.nix/1277ada3438f94a503a64f6535074ee2a106967f?narHash=sha256-9RrMhDtyppb3gqSTrPf%2BJ9i6VrFgsDTmGShHTX0rQKA%3D' (2026-08-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/643809054d65fdd466a63e3155b8c498cb483c04?narHash=sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk%3D' (2026-08-02)
  → 'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
• Updated input 'nvf':
    'github:notashelf/nvf/118286cd362be3f31700e55ae21ef71d169d06ea?narHash=sha256-MWrMx8gFp6A/ueWDdT8mNM06G9Wh6GdFZlBBLdw/MQk%3D' (2026-08-04)
  → 'github:notashelf/nvf/a213644cadd5f90bf18b0c409f08f282b30e55e3?narHash=sha256-rbOp2g0UCYt%2BevTnCGCKBQGqSMfwX4RTXneNbeHqOAk%3D' (2026-08-11)
```