### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785672383,
-        "narHash": "sha256-fFw7W2LvGX82c3Em0f05n54gL4xxRA0Lx6W1EOt6XBE=",
+        "lastModified": 1787270843,
+        "narHash": "sha256-k7vR72VPmt3lgLheVVYEtPbrJBbKgtzHRJJgw4HkJbc=",
         "owner": "archie-judd",
         "repo": "agent-sandbox.nix",
-        "rev": "601298adf27284004381b313a9dd46ea9ed9e06e",
+        "rev": "09ed90ea645d240acac4823eadffebd40ba1df84",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785389976,
-        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
+        "lastModified": 1786845137,
+        "narHash": "sha256-oQFip+v0luP8NIxJzmiW4Wu8bILsbFWom5l0zonl8hQ=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
+        "rev": "4cff07de74b50e64bdd68cd4e722ab5b6b35ee48",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786656209,
-        "narHash": "sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA=",
+        "lastModified": 1787176219,
+        "narHash": "sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf+X54NU2RLR7wnHw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c554d3441f725537854e877519f01cbd60680174",
+        "rev": "c53d643b3737e2fcd04e6cb3b3580ef50b2087a0",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1786473774,
-        "narHash": "sha256-BDedo9F6NJOw+Ii+luFZh0MVIheKqiYgiVzMWc6WB24=",
+        "lastModified": 1786958661,
+        "narHash": "sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "4a773989235545c56f408d168cb63bc41d468832",
+        "rev": "b1b7d87faa06649f7c72666107bac2c6e6459c23",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786696856,
-        "narHash": "sha256-9RrMhDtyppb3gqSTrPf+J9i6VrFgsDTmGShHTX0rQKA=",
+        "lastModified": 1787286673,
+        "narHash": "sha256-HRmx7PnoqUNtA06P/FEyygZeUJIzbNUtx4zo9Jiiz9s=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "1277ada3438f94a503a64f6535074ee2a106967f",
+        "rev": "0bedd15c76b9422a649b05e44b82666196e5246f",
         "type": "github"
       },
       "original": {
@@ -346,11 +346,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786433999,
-        "narHash": "sha256-rbOp2g0UCYt+evTnCGCKBQGqSMfwX4RTXneNbeHqOAk=",
+        "lastModified": 1787161243,
+        "narHash": "sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "a213644cadd5f90bf18b0c409f08f282b30e55e3",
+        "rev": "c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786420161,
-        "narHash": "sha256-PU4CY4GUCDFOoS67dGrc/fS6Y+d1cYZSh6nbgYqAAwE=",
+        "lastModified": 1786849542,
+        "narHash": "sha256-MS8cOa/ii1+QA8R3JWVzqEIoXimu9n50GwQDiBVTFOM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3a646bd5daa3af78a78a1cb32329cb72d18fcae0",
+        "rev": "b211eadeba8b180da9453ec3413a8a3535c85b3f",
         "type": "github"
       },
       "original": {
@@ -529,11 +529,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785945821,
-        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'agent-sandbox':
    'github:archie-judd/agent-sandbox.nix/601298adf27284004381b313a9dd46ea9ed9e06e?narHash=sha256-fFw7W2LvGX82c3Em0f05n54gL4xxRA0Lx6W1EOt6XBE%3D' (2026-08-02)
  → 'github:archie-judd/agent-sandbox.nix/09ed90ea645d240acac4823eadffebd40ba1df84?narHash=sha256-k7vR72VPmt3lgLheVVYEtPbrJBbKgtzHRJJgw4HkJbc%3D' (2026-08-21)
• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/15abb8c98f336cd8bd840d71059adebabe60bf04?narHash=sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU%3D' (2026-07-30)
  → 'github:nix-darwin/nix-darwin/4cff07de74b50e64bdd68cd4e722ab5b6b35ee48?narHash=sha256-oQFip%2Bv0luP8NIxJzmiW4Wu8bILsbFWom5l0zonl8hQ%3D' (2026-08-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c554d3441f725537854e877519f01cbd60680174?narHash=sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA%3D' (2026-08-13)
  → 'github:nix-community/home-manager/c53d643b3737e2fcd04e6cb3b3580ef50b2087a0?narHash=sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf%2BX54NU2RLR7wnHw%3D' (2026-08-19)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/4a773989235545c56f408d168cb63bc41d468832?narHash=sha256-BDedo9F6NJOw%2BIi%2BluFZh0MVIheKqiYgiVzMWc6WB24%3D' (2026-08-11)
  → 'github:nix-community/lanzaboote/b1b7d87faa06649f7c72666107bac2c6e6459c23?narHash=sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0%3D' (2026-08-17)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/3a646bd5daa3af78a78a1cb32329cb72d18fcae0?narHash=sha256-PU4CY4GUCDFOoS67dGrc/fS6Y%2Bd1cYZSh6nbgYqAAwE%3D' (2026-08-11)
  → 'github:oxalica/rust-overlay/b211eadeba8b180da9453ec3413a8a3535c85b3f?narHash=sha256-MS8cOa/ii1%2BQA8R3JWVzqEIoXimu9n50GwQDiBVTFOM%3D' (2026-08-16)
• Updated input 'llm-agents':
    'github:numtide/llm-agents.nix/1277ada3438f94a503a64f6535074ee2a106967f?narHash=sha256-9RrMhDtyppb3gqSTrPf%2BJ9i6VrFgsDTmGShHTX0rQKA%3D' (2026-08-14)
  → 'github:numtide/llm-agents.nix/0bedd15c76b9422a649b05e44b82666196e5246f?narHash=sha256-HRmx7PnoqUNtA06P/FEyygZeUJIzbNUtx4zo9Jiiz9s%3D' (2026-08-21)
• Updated input 'llm-agents/treefmt-nix':
    'github:numtide/treefmt-nix/ae7910970dddc408fe6ab1c8e4b277bb21d72dc0?narHash=sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw%3D' (2026-08-05)
  → 'github:numtide/treefmt-nix/27b3b12a8e6375f28ebe122f07d230ca5459bbfa?narHash=sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE%3D' (2026-08-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
  → 'github:nixos/nixpkgs/ffb3c9b700e759be2ef13237c9d8f953b32a1e46?narHash=sha256-RD2kNWCG%2BBjo6h%2BJVjWVNntZs2GtRoeY2xHjts/FNkA%3D' (2026-08-19)
• Updated input 'nvf':
    'github:notashelf/nvf/a213644cadd5f90bf18b0c409f08f282b30e55e3?narHash=sha256-rbOp2g0UCYt%2BevTnCGCKBQGqSMfwX4RTXneNbeHqOAk%3D' (2026-08-11)
  → 'github:notashelf/nvf/c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08?narHash=sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI%3D' (2026-08-19)
```