### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787270843,
-        "narHash": "sha256-k7vR72VPmt3lgLheVVYEtPbrJBbKgtzHRJJgw4HkJbc=",
+        "lastModified": 1787696194,
+        "narHash": "sha256-RF+VyL4XaRzBIr+o3K2nF0CtmzFTG2HpdK39X49ILMs=",
         "owner": "archie-judd",
         "repo": "agent-sandbox.nix",
-        "rev": "09ed90ea645d240acac4823eadffebd40ba1df84",
+        "rev": "1a33c51a62ba14f16f59fe0c2febeb63ba73e0be",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1785782307,
-        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785627969,
-        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787176219,
-        "narHash": "sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf+X54NU2RLR7wnHw=",
+        "lastModified": 1787715947,
+        "narHash": "sha256-jT6g5aWwA6TrIUJhqQ9ssm8W5e8vAl2Bv8gddEKKVNU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c53d643b3737e2fcd04e6cb3b3580ef50b2087a0",
+        "rev": "7690127e7e1c90ab1dcaff525d0dafbeb7e14182",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1786958661,
-        "narHash": "sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0=",
+        "lastModified": 1787658383,
+        "narHash": "sha256-I+zCjwAtkmgnet+08H+7HV8qJjf6BoFMYsX/8lMiW/s=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "b1b7d87faa06649f7c72666107bac2c6e6459c23",
+        "rev": "69cf334f9dbc11213c6228c97e9b32924d51443f",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1787286673,
-        "narHash": "sha256-HRmx7PnoqUNtA06P/FEyygZeUJIzbNUtx4zo9Jiiz9s=",
+        "lastModified": 1787719661,
+        "narHash": "sha256-FLBOjXOSh2WvMG6id+ks018WQ7HiA4yPPlIagpTc0DM=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "0bedd15c76b9422a649b05e44b82666196e5246f",
+        "rev": "76b78a399417964e9133aed0c0a9493616c3508e",
         "type": "github"
       },
       "original": {
@@ -346,11 +346,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787161243,
-        "narHash": "sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI=",
+        "lastModified": 1787514376,
+        "narHash": "sha256-wS5a1tumQcmwamA4BpSvf2Idd/P/zOQNU1hY53EzfoM=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08",
+        "rev": "460dad9e777df4008309f1d731a47b299dc7b41e",
         "type": "github"
       },
       "original": {
@@ -407,11 +407,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786849542,
-        "narHash": "sha256-MS8cOa/ii1+QA8R3JWVzqEIoXimu9n50GwQDiBVTFOM=",
+        "lastModified": 1787454509,
+        "narHash": "sha256-r4LDUF+zmJnkftvCVkCrUhSJazsf6EVJF+V2l4/MYbI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b211eadeba8b180da9453ec3413a8a3535c85b3f",
+        "rev": "f60c1b57ff805a46b5175c76fc981fb4f81efbcc",
         "type": "github"
       },
       "original": {

--- a/modules/opencode.nix
+++ b/modules/opencode.nix
@@ -33,10 +33,12 @@ let
     }
   );
 
+  # TODO: Drop opencode SSE reconnect patch
+  # Reconnect SSE event stream after Android screen-lock freeze leaves
+  # the fetch hanging on a half-open socket, and resync stale session
+  # views on resume.
+  # labels: host:nea, module: opencode
   opencode = pkgs.opencode.overrideAttrs (old: {
-    # Reconnect SSE event stream after Android screen-lock freeze leaves
-    # the fetch hanging on a half-open socket, and resync stale session
-    # views on resume.
     patches = [ ./opencode-sse-freeze-resume.patch ];
     postPatch = (old.postPatch or "") + ''
       cp ${pwaManifest} packages/app/public/site.webmanifest

--- a/modules/opencode.nix
+++ b/modules/opencode.nix
@@ -33,35 +33,15 @@ let
     }
   );
 
-  # TODO: Drop opencode override when updated in nixpkgs
-  # Issue URL: https://github.com/tlvince/nixos-config/issues/509
-  # labels: host:nea
-  opencode =
-    let
-      base = pkgs.opencode.overrideAttrs (old: {
-        version = "1.18.21";
-        # Reconnect SSE event stream after Android screen-lock freeze leaves
-        # the fetch hanging on a half-open socket, and resync stale session
-        # views on resume.
-        patches = [ ./opencode-sse-freeze-resume.patch ];
-        postPatch = (old.postPatch or "") + ''
-          cp ${pwaManifest} packages/app/public/site.webmanifest
-        '';
-        src = pkgs.fetchFromGitHub {
-          owner = "anomalyco";
-          repo = "opencode";
-          tag = "v1.18.21";
-          hash = "sha256-WKG/lts+wzDjYJ5pOZ0X4Kb0rJ1TzYQzQgjyQBY+bxs=";
-        };
-      });
-    in
-    base.overrideAttrs (old: {
-      passthru = old.passthru // {
-        node_modules = old.passthru.node_modules.overrideAttrs (_: {
-          outputHash = "sha256-WqEZQCVl4oQFVbrhlWVaBW+JiSqjSK+LILPkDV9Avds=";
-        });
-      };
-    });
+  opencode = pkgs.opencode.overrideAttrs (old: {
+    # Reconnect SSE event stream after Android screen-lock freeze leaves
+    # the fetch hanging on a half-open socket, and resync stale session
+    # views on resume.
+    patches = [ ./opencode-sse-freeze-resume.patch ];
+    postPatch = (old.postPatch or "") + ''
+      cp ${pwaManifest} packages/app/public/site.webmanifest
+    '';
+  });
 in
 {
   services.nginx = {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'agent-sandbox':
    'github:archie-judd/agent-sandbox.nix/09ed90ea645d240acac4823eadffebd40ba1df84?narHash=sha256-k7vR72VPmt3lgLheVVYEtPbrJBbKgtzHRJJgw4HkJbc%3D' (2026-08-21)
  → 'github:archie-judd/agent-sandbox.nix/1a33c51a62ba14f16f59fe0c2febeb63ba73e0be?narHash=sha256-RF%2BVyL4XaRzBIr%2Bo3K2nF0CtmzFTG2HpdK39X49ILMs%3D' (2026-08-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c53d643b3737e2fcd04e6cb3b3580ef50b2087a0?narHash=sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf%2BX54NU2RLR7wnHw%3D' (2026-08-19)
  → 'github:nix-community/home-manager/7690127e7e1c90ab1dcaff525d0dafbeb7e14182?narHash=sha256-jT6g5aWwA6TrIUJhqQ9ssm8W5e8vAl2Bv8gddEKKVNU%3D' (2026-08-26)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/b1b7d87faa06649f7c72666107bac2c6e6459c23?narHash=sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0%3D' (2026-08-17)
  → 'github:nix-community/lanzaboote/69cf334f9dbc11213c6228c97e9b32924d51443f?narHash=sha256-I%2BzCjwAtkmgnet%2B08H%2B7HV8qJjf6BoFMYsX/8lMiW/s%3D' (2026-08-25)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/2c71e194474d13de031d729b729c968ddbe3507f?narHash=sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw%3D' (2026-08-03)
  → 'github:ipetkov/crane/692f7e9ef2ece8125b466f66f2af532b3edaed0d?narHash=sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs%3D' (2026-08-21)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/git-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9?narHash=sha256-ReRHaLgr/uVqdD8afFSn%2BmyXIfpHeOhP0yYe0TJqAA8%3D' (2026-07-17)
  → 'github:cachix/git-hooks.nix/809414f0cdadf82cf11b06c2b29ba9b3168b3297?narHash=sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh%2B7CBnbCYsk%3D' (2026-08-22)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/b211eadeba8b180da9453ec3413a8a3535c85b3f?narHash=sha256-MS8cOa/ii1%2BQA8R3JWVzqEIoXimu9n50GwQDiBVTFOM%3D' (2026-08-16)
  → 'github:oxalica/rust-overlay/f60c1b57ff805a46b5175c76fc981fb4f81efbcc?narHash=sha256-r4LDUF%2BzmJnkftvCVkCrUhSJazsf6EVJF%2BV2l4/MYbI%3D' (2026-08-23)
• Updated input 'llm-agents':
    'github:numtide/llm-agents.nix/0bedd15c76b9422a649b05e44b82666196e5246f?narHash=sha256-HRmx7PnoqUNtA06P/FEyygZeUJIzbNUtx4zo9Jiiz9s%3D' (2026-08-21)
  → 'github:numtide/llm-agents.nix/76b78a399417964e9133aed0c0a9493616c3508e?narHash=sha256-FLBOjXOSh2WvMG6id%2Bks018WQ7HiA4yPPlIagpTc0DM%3D' (2026-08-26)
• Updated input 'llm-agents/flake-parts':
    'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
  → 'github:hercules-ci/flake-parts/9d0d87172c374f89da73c1cfe6d81ae62feac1f1?narHash=sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw%3D' (2026-08-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ffb3c9b700e759be2ef13237c9d8f953b32a1e46?narHash=sha256-RD2kNWCG%2BBjo6h%2BJVjWVNntZs2GtRoeY2xHjts/FNkA%3D' (2026-08-19)
  → 'github:nixos/nixpkgs/56c02bc00adcf003215cc4bd996d6efaf4cff188?narHash=sha256-9i/VTdusq/%2BNM/tz%2BJ1Re%2BojkMB8MBf0QshnYfzHz30%3D' (2026-08-23)
• Updated input 'nvf':
    'github:notashelf/nvf/c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08?narHash=sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI%3D' (2026-08-19)
  → 'github:notashelf/nvf/460dad9e777df4008309f1d731a47b299dc7b41e?narHash=sha256-wS5a1tumQcmwamA4BpSvf2Idd/P/zOQNU1hY53EzfoM%3D' (2026-08-23)
```