### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787270843,
-        "narHash": "sha256-k7vR72VPmt3lgLheVVYEtPbrJBbKgtzHRJJgw4HkJbc=",
+        "lastModified": 1787944199,
+        "narHash": "sha256-biRymPNrMO9HN6rRrQ81f3nQnixEiwT59toPZlxQ/rE=",
         "owner": "archie-judd",
         "repo": "agent-sandbox.nix",
-        "rev": "09ed90ea645d240acac4823eadffebd40ba1df84",
+        "rev": "11c87ac626b97efd11711c7d9b68446d58295338",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1785782307,
-        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785627969,
-        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787176219,
-        "narHash": "sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf+X54NU2RLR7wnHw=",
+        "lastModified": 1788229478,
+        "narHash": "sha256-G0F2rFORVcFkEvVdE/qWQTnYekIc77YP5/vRF9nZlxU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c53d643b3737e2fcd04e6cb3b3580ef50b2087a0",
+        "rev": "1dc2d1f720ab17fc7981e087346bf54b26d284b1",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,11 @@
     },
     "jail-nix": {
       "locked": {
-        "lastModified": 1776230864,
-        "narHash": "sha256-YsEjjdOsGEzTeD+iT7ONh071BqWAOQWpzYVei3okAXE=",
+        "lastModified": 1783532714,
+        "narHash": "sha256-2MC7ivWBgyhHh6WBIvj1LRz00s8mZTti0iVyqeF+K/s=",
         "owner": "~alexdavid",
         "repo": "jail.nix",
-        "rev": "404e7da9da5ab9aa643666682b2ba1312fa5fbe8",
+        "rev": "e9210ebaa4b264cc1710a2a23254cc0402c34d0f",
         "type": "sourcehut"
       },
       "original": {
@@ -292,11 +292,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1786958661,
-        "narHash": "sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0=",
+        "lastModified": 1788173567,
+        "narHash": "sha256-C4/tvPY34n/YfQZUIMRNAHzidAG+qUaU6qBqd07OS2c=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "b1b7d87faa06649f7c72666107bac2c6e6459c23",
+        "rev": "d2326588612480c96d5fefb885f57b4660a85584",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1787286673,
-        "narHash": "sha256-HRmx7PnoqUNtA06P/FEyygZeUJIzbNUtx4zo9Jiiz9s=",
+        "lastModified": 1788258647,
+        "narHash": "sha256-eRtZ4oKZ9/We8qfuqUoISAuqeaJnsIKYPW9JDXqPjHA=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "0bedd15c76b9422a649b05e44b82666196e5246f",
+        "rev": "68c363aaa0acf2337a8e8b311bc780bcb184019c",
         "type": "github"
       },
       "original": {
@@ -346,11 +346,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {
@@ -401,11 +401,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787161243,
-        "narHash": "sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI=",
+        "lastModified": 1788115442,
+        "narHash": "sha256-hpEx9BvlTtnONKZK/GAdVtQriW14x0ec+Ir5uafNPYY=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08",
+        "rev": "f33afa7a878cfac9bebab42d8eccc7680c389cd6",
         "type": "github"
       },
       "original": {
@@ -423,11 +423,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786849542,
-        "narHash": "sha256-MS8cOa/ii1+QA8R3JWVzqEIoXimu9n50GwQDiBVTFOM=",
+        "lastModified": 1788077403,
+        "narHash": "sha256-c20YZQKzQ27qC6Wh729fWRTpI7oV4+7Ur4icKssD4Wc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b211eadeba8b180da9453ec3413a8a3535c85b3f",
+        "rev": "89e26eeaafa88a2ede4778734acc794ff0299beb",
         "type": "github"
       },
       "original": {

--- a/hosts/kunkun.nix
+++ b/hosts/kunkun.nix
@@ -91,7 +91,18 @@
     };
     useDHCP = false;
   };
-  nixpkgs.hostPlatform = "aarch64-linux";
+  nixpkgs = {
+    hostPlatform = "aarch64-linux";
+    # TODO: Remove rdma-core dependency
+    # libpcap defaults withRdma to true when rdma-core is available, pulling
+    # rdma-core -> perl into the closure. Nothing on this host uses RDMA.
+    # labels: host:kunkun, host:nea
+    overlays = [
+      (final: prev: {
+        libpcap = prev.libpcap.override { withRdma = false; };
+      })
+    ];
+  };
 
   programs.vim = {
     enable = true;

--- a/hosts/kunkun.nix
+++ b/hosts/kunkun.nix
@@ -10,9 +10,7 @@
     # https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/profiles
     (modulesPath + "/profiles/headless.nix")
     (modulesPath + "/profiles/minimal.nix")
-    # TODO: restore perlless profile
-    # labels: host:kunkun
-    #(modulesPath + "/profiles/perlless.nix")
+    (modulesPath + "/profiles/perlless.nix")
     (modulesPath + "/profiles/qemu-guest.nix")
 
     ../modules/host-common.nix

--- a/hosts/nea.nix
+++ b/hosts/nea.nix
@@ -159,7 +159,18 @@
     };
   };
 
-  nixpkgs.hostPlatform = "aarch64-linux";
+  nixpkgs = {
+    hostPlatform = "aarch64-linux";
+    # TODO: Remove rdma-core dependency
+    # libpcap defaults withRdma to true when rdma-core is available, pulling
+    # rdma-core -> perl into the closure. Nothing on this host uses RDMA.
+    # labels: host:kunkun, host:nea
+    overlays = [
+      (final: prev: {
+        libpcap = prev.libpcap.override { withRdma = false; };
+      })
+    ];
+  };
 
   programs.vim = {
     enable = true;


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'agent-sandbox':
    'github:archie-judd/agent-sandbox.nix/09ed90ea645d240acac4823eadffebd40ba1df84?narHash=sha256-k7vR72VPmt3lgLheVVYEtPbrJBbKgtzHRJJgw4HkJbc%3D' (2026-08-21)
  → 'github:archie-judd/agent-sandbox.nix/11c87ac626b97efd11711c7d9b68446d58295338?narHash=sha256-biRymPNrMO9HN6rRrQ81f3nQnixEiwT59toPZlxQ/rE%3D' (2026-08-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c53d643b3737e2fcd04e6cb3b3580ef50b2087a0?narHash=sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf%2BX54NU2RLR7wnHw%3D' (2026-08-19)
  → 'github:nix-community/home-manager/1dc2d1f720ab17fc7981e087346bf54b26d284b1?narHash=sha256-G0F2rFORVcFkEvVdE/qWQTnYekIc77YP5/vRF9nZlxU%3D' (2026-09-01)
• Updated input 'jail-nix':
    'sourcehut:~alexdavid/jail.nix/404e7da9da5ab9aa643666682b2ba1312fa5fbe8?narHash=sha256-YsEjjdOsGEzTeD%2BiT7ONh071BqWAOQWpzYVei3okAXE%3D' (2026-04-15)
  → 'sourcehut:~alexdavid/jail.nix/e9210ebaa4b264cc1710a2a23254cc0402c34d0f?narHash=sha256-2MC7ivWBgyhHh6WBIvj1LRz00s8mZTti0iVyqeF%2BK/s%3D' (2026-07-08)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/b1b7d87faa06649f7c72666107bac2c6e6459c23?narHash=sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0%3D' (2026-08-17)
  → 'github:nix-community/lanzaboote/d2326588612480c96d5fefb885f57b4660a85584?narHash=sha256-C4/tvPY34n/YfQZUIMRNAHzidAG%2BqUaU6qBqd07OS2c%3D' (2026-08-31)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/2c71e194474d13de031d729b729c968ddbe3507f?narHash=sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw%3D' (2026-08-03)
  → 'github:ipetkov/crane/692f7e9ef2ece8125b466f66f2af532b3edaed0d?narHash=sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs%3D' (2026-08-21)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/git-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9?narHash=sha256-ReRHaLgr/uVqdD8afFSn%2BmyXIfpHeOhP0yYe0TJqAA8%3D' (2026-07-17)
  → 'github:cachix/git-hooks.nix/809414f0cdadf82cf11b06c2b29ba9b3168b3297?narHash=sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh%2B7CBnbCYsk%3D' (2026-08-22)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/b211eadeba8b180da9453ec3413a8a3535c85b3f?narHash=sha256-MS8cOa/ii1%2BQA8R3JWVzqEIoXimu9n50GwQDiBVTFOM%3D' (2026-08-16)
  → 'github:oxalica/rust-overlay/89e26eeaafa88a2ede4778734acc794ff0299beb?narHash=sha256-c20YZQKzQ27qC6Wh729fWRTpI7oV4%2B7Ur4icKssD4Wc%3D' (2026-08-30)
• Updated input 'llm-agents':
    'github:numtide/llm-agents.nix/0bedd15c76b9422a649b05e44b82666196e5246f?narHash=sha256-HRmx7PnoqUNtA06P/FEyygZeUJIzbNUtx4zo9Jiiz9s%3D' (2026-08-21)
  → 'github:numtide/llm-agents.nix/68c363aaa0acf2337a8e8b311bc780bcb184019c?narHash=sha256-eRtZ4oKZ9/We8qfuqUoISAuqeaJnsIKYPW9JDXqPjHA%3D' (2026-09-01)
• Updated input 'llm-agents/flake-parts':
    'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
  → 'github:hercules-ci/flake-parts/9d0d87172c374f89da73c1cfe6d81ae62feac1f1?narHash=sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw%3D' (2026-08-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ffb3c9b700e759be2ef13237c9d8f953b32a1e46?narHash=sha256-RD2kNWCG%2BBjo6h%2BJVjWVNntZs2GtRoeY2xHjts/FNkA%3D' (2026-08-19)
  → 'github:nixos/nixpkgs/34ab99075ac4f7e40cf037eef32cb1c360bb85e9?narHash=sha256-hn1oU2rue2SYK8dAr8%2BWNZWtbsz1S2W5mnHlSEuh3bo%3D' (2026-08-31)
• Updated input 'nvf':
    'github:notashelf/nvf/c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08?narHash=sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI%3D' (2026-08-19)
  → 'github:notashelf/nvf/f33afa7a878cfac9bebab42d8eccc7680c389cd6?narHash=sha256-hpEx9BvlTtnONKZK/GAdVtQriW14x0ec%2BIr5uafNPYY%3D' (2026-08-30)
```