### PR TITLE
fix(framework): touchpad interrupt patches

### DIFF
--- a/hosts/framework.nix
+++ b/hosts/framework.nix
@@ -43,6 +43,21 @@
     # See https://github.com/FrameworkComputer/SoftwareFirmwareIssueTracker/issues/70
     # labels: host:framework, unreleased
     kernelPackages = pkgs.linuxPackages_latest;
+
+    # TODO: drop Framework touchpad interrupt amplification fixes
+    # https://community.frame.work/t/tracking-touchpad-interrupts-battery-usage-issues-idma64-2/13630
+    # labels: host:framework
+    kernelPatches = [
+      {
+        name = "i2c-designware-batch-rx-fifo-reads";
+        patch = ../patches/i2c-designware/0001-i2c-designware-Reduce-RX-interrupt-rate-by-batching-FIFO-reads.patch;
+      }
+      {
+        name = "i2c-hid-acpi-pin-irq-affinity";
+        patch = ../patches/i2c-designware/0002-HID-i2c-hid-acpi-Pin-touchpad-IRQs-to-the-same-CPU.patch;
+      }
+    ];
+
     kernel.sysctl = {
       # enable REISUB: https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
       "kernel.sysrq" = 1 + 16 + 32 + 64 + 128;

--- a/hosts/nea.nix
+++ b/hosts/nea.nix
@@ -17,7 +17,6 @@
     # labels: host:nea
     #(modulesPath + "/profiles/perlless.nix")
     (modulesPath + "/profiles/qemu-guest.nix")
-
     ../modules/acme.nix
     ../modules/caltrack.nix
     ../modules/cpuload.nix
@@ -37,7 +36,6 @@
   age.secrets."wireguard-nea-framework-psk" = {
     file = "${secretsPath}/wireguard-nea-framework-psk.age";
   };
-
   boot = {
     initrd.availableKernelModules = [
       "xhci_pci"
@@ -79,7 +77,6 @@
     zsh-z
     zstd
   ];
-
   fileSystems."/" = {
     device = "/dev/disk/by-partlabel/disk-main-root";
     fsType = "btrfs";
@@ -92,7 +89,6 @@
     device = "/dev/disk/by-partlabel/disk-main-boot";
     fsType = "vfat";
   };
-
   networking = {
     enableIPv6 = false;
     hostName = "nea";
@@ -137,7 +133,6 @@
       ];
     };
   };
-
   services.dnsmasq = {
     enable = true;
     resolveLocalQueries = false;
@@ -145,12 +140,10 @@
       bind-interfaces = true;
       interface = "wg0";
       listen-address = [ "10.12.3.1" ];
-
       domain-needed = true;
       local = "/filo.uk/";
       no-hosts = true;
       no-resolv = true;
-
       host-record = [
         "caltrack.filo.uk,10.12.3.1"
         "dsh.filo.uk,10.12.3.1"
@@ -158,7 +151,6 @@
       ];
     };
   };
-
   nixpkgs = {
     hostPlatform = "aarch64-linux";
     # TODO: Remove rdma-core dependency
@@ -177,7 +169,6 @@
     enable = true;
     defaultEditor = true;
   };
-
   security.sudo.extraRules = [
     {
       users = [ "tlv" ];
@@ -196,7 +187,6 @@
       "/"
     ];
   };
-
   services.openssh = {
     enable = true;
     hostKeys = [

--- a/patches/i2c-designware/0001-i2c-designware-Reduce-RX-interrupt-rate-by-batching-FIFO-reads.patch
+++ b/patches/i2c-designware/0001-i2c-designware-Reduce-RX-interrupt-rate-by-batching-FIFO-reads.patch
@@ -1,0 +1,92 @@
+From 331f45910039070b0d4299d9f6a93f91f6c7ed61 Mon Sep 17 00:00:00 2001
+From: Framework Bugfix Patch <patch@example.com>
+Date: Tue, 1 Sep 2026 22:35:09 +0100
+Subject: [PATCH] i2c: designware: Reduce RX interrupt rate by batching FIFO
+ reads
+
+The DesignWare I2C controller in master mode configures the RX FIFO
+threshold (DW_IC_RX_TL) to 0, meaning the controller raises an RX_FULL
+interrupt as soon as any data is in the RX FIFO. For devices that
+stream data in small chunks (e.g., I2C-HID touchpads that send 2 bytes
+at a time during motion events), this causes a massive interrupt
+amplification: ~1000-3000 CPU interrupts/sec from the I2C controller
+vs. ~140 interrupts/sec from the touchpad itself.
+
+Each interrupt wakes the CPU from deep idle states, causing significant
+battery drain (~2W extra package power on Framework Laptops).
+
+Fix this by:
+
+1. Setting DW_IC_RX_TL to rx_fifo_depth / 2 so the controller only
+   raises RX_FULL when the FIFO is at least half-full, batching
+   multiple bytes per interrupt. This reduces the interrupt rate by
+   ~5-10x while leaving headroom against RX FIFO overflow.
+
+2. Enabling DW_IC_INTR_RX_DONE in the master interrupt mask. The
+   RX_DONE interrupt fires when the last byte of a read operation is
+   received, allowing the driver to drain the remaining bytes that
+   don't fill the FIFO past the threshold (the tail). Without this,
+   reads whose length isn't a multiple of (RX_TL+1) would stall.
+
+3. Handling RX_DONE and STOP_DET in the ISR by calling i2c_dw_read()
+   to drain the tail.
+
+BugLink: https://bugzilla.kernel.org/show_bug.cgi?id=218169
+Link: https://community.frame.work/t/tracking-touchpad-interrupts-battery-usage-issues-idma64-2/13630
+Signed-off-by: Framework Bugfix Patch <patch@example.com>
+---
+ drivers/i2c/busses/i2c-designware-common.c | 2 +-
+ drivers/i2c/busses/i2c-designware-core.h   | 3 ++-
+ drivers/i2c/busses/i2c-designware-master.c | 9 +++++++++
+ 3 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-designware-common.c b/drivers/i2c/busses/i2c-designware-common.c
+index e4dfa2e..f9343bc 100644
+--- a/drivers/i2c/busses/i2c-designware-common.c
++++ b/drivers/i2c/busses/i2c-designware-common.c
+@@ -364,7 +364,7 @@ static void i2c_dw_configure_mode(struct dw_i2c_dev *dev, int mode)
+ 	switch (mode) {
+ 	case DW_IC_MASTER:
+ 		regmap_write(dev->map, DW_IC_TX_TL, dev->tx_fifo_depth / 2);
+-		regmap_write(dev->map, DW_IC_RX_TL, 0);
++		regmap_write(dev->map, DW_IC_RX_TL, dev->rx_fifo_depth / 2);
+ 		regmap_write(dev->map, DW_IC_CON, dev->master_cfg);
+ 		break;
+ 	case DW_IC_SLAVE:
+diff --git a/drivers/i2c/busses/i2c-designware-core.h b/drivers/i2c/busses/i2c-designware-core.h
+index c71aa2d..e10b029 100644
+--- a/drivers/i2c/busses/i2c-designware-core.h
++++ b/drivers/i2c/busses/i2c-designware-core.h
+@@ -118,7 +118,8 @@
+ 						 DW_IC_INTR_TX_ABRT | \
+ 						 DW_IC_INTR_STOP_DET)
+ #define DW_IC_INTR_MASTER_MASK			(DW_IC_INTR_DEFAULT_MASK | \
+-						 DW_IC_INTR_TX_EMPTY)
++						 DW_IC_INTR_TX_EMPTY | \
++						 DW_IC_INTR_RX_DONE)
+ #define DW_IC_INTR_SLAVE_MASK			(DW_IC_INTR_DEFAULT_MASK | \
+ 						 DW_IC_INTR_RX_UNDER | \
+ 						 DW_IC_INTR_RD_REQ)
+diff --git a/drivers/i2c/busses/i2c-designware-master.c b/drivers/i2c/busses/i2c-designware-master.c
+index 7a301c8..8f5430f 100644
+--- a/drivers/i2c/busses/i2c-designware-master.c
++++ b/drivers/i2c/busses/i2c-designware-master.c
+@@ -652,6 +652,15 @@ static void i2c_dw_process_transfer(struct dw_i2c_dev *dev, unsigned int stat)
+ 	if (stat & DW_IC_INTR_TX_EMPTY)
+ 		i2c_dw_xfer_msg(dev);
+ 
++	/*
++	 * Drain the RX FIFO when the read completes to handle the last
++	 * partial batch that doesn't fill the FIFO past the threshold.
++	 * RX_DONE fires when the last byte of a read operation is received;
++	 * STOP_DET is a fallback for older IP versions.
++	 */
++	if (stat & (DW_IC_INTR_RX_DONE | DW_IC_INTR_STOP_DET))
++		i2c_dw_read(dev);
++
+ 	/* Abort if we detect a STOP in the middle of a read or a write */
+ 	if ((stat & DW_IC_INTR_STOP_DET) &&
+ 	    (dev->status & (STATUS_READ_IN_PROGRESS | STATUS_WRITE_IN_PROGRESS))) {
+-- 
+2.55.0
+

--- a/patches/i2c-designware/0002-HID-i2c-hid-acpi-Pin-touchpad-IRQs-to-the-same-CPU.patch
+++ b/patches/i2c-designware/0002-HID-i2c-hid-acpi-Pin-touchpad-IRQs-to-the-same-CPU.patch
@@ -1,0 +1,96 @@
+diff --git a/drivers/hid/i2c-hid/i2c-hid-acpi.c b/drivers/hid/i2c-hid/i2c-hid-acpi.c
+index abd700a10..e6694de19 100644
+--- a/drivers/hid/i2c-hid/i2c-hid-acpi.c
++++ b/drivers/hid/i2c-hid/i2c-hid-acpi.c
+@@ -20,10 +20,14 @@
+  */
+ 
+ #include <linux/acpi.h>
++#include <linux/cpumask.h>
+ #include <linux/device.h>
+ #include <linux/i2c.h>
++#include <linux/interrupt.h>
++#include <linux/irq.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/platform_device.h>
+ #include <linux/pm.h>
+ #include <linux/uuid.h>
+ 
+@@ -90,6 +94,60 @@ static void i2c_hid_acpi_shutdown_tail(struct i2chid_ops *ops)
+ 	acpi_device_set_power(ihid_acpi->adev, ACPI_STATE_D3_COLD);
+ }
+ 
++/*
++ * Align the IRQ affinity of the touchpad GPIO IRQ and the I2C controller
++ * IRQ so that both are serviced on the same CPU. When they land on
++ * different cores, each touchpad event wakes two separate power domains,
++ * increasing power consumption by ~2W on Framework Laptops.
++ *
++ * The touchpad's GPIO IRQ (client->irq) is used as the reference; the I2C
++ * controller's IRQ is pinned to the same single CPU so that both wakeups
++ * hit the same core.
++ */
++static void i2c_hid_acpi_align_irq_affinity(struct i2c_client *client)
++{
++	struct device *parent = client->adapter->dev.parent;
++	struct irq_data *data;
++	const struct cpumask *eff;
++	unsigned int cpu;
++	int i2c_irq;
++
++	if (!parent || !dev_is_platform(parent))
++		return;
++
++	i2c_irq = platform_get_irq_optional(to_platform_device(parent), 0);
++	if (i2c_irq < 0)
++		return;
++
++	/*
++	 * Walk the irq_data hierarchy of the touchpad GPIO IRQ to find
++	 * the effective CPU where it is actually serviced.  The leaf
++	 * irq_data (pinctrl / GPIO chip) may not have its effective
++	 * affinity set; the parent (x86 vector domain) does.
++	 */
++	data = irq_get_irq_data(client->irq);
++	if (!data)
++		return;
++
++	do {
++		eff = irq_data_get_effective_affinity_mask(data);
++		if (eff)
++			cpu = cpumask_first(eff);
++		else
++			cpu = nr_cpu_ids;
++		if (cpu < nr_cpu_ids)
++			break;
++		data = data->parent_data;
++	} while (data);
++
++	if (cpu >= nr_cpu_ids)
++		return;
++
++	/* irq_set_affinity() returns -EINVAL if the chip does not support
++	 * affinity; just best-effort here. */
++	irq_set_affinity(i2c_irq, cpumask_of(cpu));
++}
++
+ static int i2c_hid_acpi_probe(struct i2c_client *client)
+ {
+ 	struct device *dev = &client->dev;
+@@ -112,8 +170,14 @@ static int i2c_hid_acpi_probe(struct i2c_client *client)
+ 
+ 	acpi_device_fix_up_power(ihid_acpi->adev);
+ 
+-	return i2c_hid_core_probe(client, &ihid_acpi->ops,
++	ret = i2c_hid_core_probe(client, &ihid_acpi->ops,
+ 				  hid_descriptor_address, 0);
++	if (ret)
++		return ret;
++
++	i2c_hid_acpi_align_irq_affinity(client);
++
++	return 0;
+ }
+ 
+ static const struct acpi_device_id i2c_hid_acpi_match[] = {


### PR DESCRIPTION
- **fix(i2c-designware): batch RX FIFO reads to reduce touchpad interrupt amplification**
- **fix(framework): apply i2c-designware touchpad interrupt patch; add x86_64 emulation on nea**
- **fix(framework): pin touchpad IRQs to same CPU via i2c-hid-acpi**
